### PR TITLE
Coordfix

### DIFF
--- a/py/desisurvey/nextfield.py
+++ b/py/desisurvey/nextfield.py
@@ -100,10 +100,6 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
     """
                 
     tobs = Time(dateobs, format='jd', scale='ut1')
-    #kitt_peak = EarthLocation(lat=31.9634*u.deg, lon=-111.6003*u.deg, height=2120*u.m)
-    #kitt_peak_long = Longitude(-111.5984796*u.deg)
-    #iers.IERS.iers_table = iers.IERS_A.open('finals2000A.all.txt')
-    #iers.IERS.iers_table = iers.IERS_A.open(download_file(iers.IERS_A_URL, cache=True))
     
     #Find the Julian date of the previous midnight
     if (dateobs-math.floor(dateobs) >= 0.5):
@@ -132,11 +128,6 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
     #Correct with the equation of equinoxes to get the current apparent sidereal time
     gast = gmst+eqeq
     
-    #gast_2 = tobs.sidereal_time('apparent', 'greenwich')
-    
-    #print gast
-    #print gast_2
-    
     #Add the longitude of the observatory to get the local sidereal time
     last = gast-111.5984796
         
@@ -144,25 +135,6 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
     if last >= 360:
         n = math.floor(last/360)
         last = last-360*n
-        
-    #hour = math.floor(last/15)
-    #minute = math.floor((last/15-hour)*60)
-    #second = ((last/15-hour)*60-minute)*60
-    
-    #print( str(int(hour)) + "h" + str(int(minute)) + "m" + str(second) +"s")
-    
-    #last_2 = gast_2+kitt_peak_long
-    
-    #last = last_2.deg
-
-    #print("dateobs = " + str(dateobs))
-    #print("JD_0 = " + str(JD_0))
-    #print("D_0 = " + str(D_0))
-    #print("D = " + str(D))
-    #print("T = " + str(T))
-    #print("H = " + str(H))
-    #print("GMST = " + str(GMST))
-    #print("LAST = " + str(LAST))
     
     #Use astropy to calculate the position of the Sun.
     pos_sun = coordinates.get_sun(tobs)
@@ -176,7 +148,6 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
         ha_sun = ha_sun + 360
     if (ha_sun > 360):
         ha_sun = ha_sun - 360
-    #print("ha_sun = " + str(ha_sun))
     
     #Calculate the altitude of the Sun to determine if it is up
     alt_sun = (math.asin(math.sin(dec_sun*math.pi/180)
@@ -184,16 +155,6 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
                          +math.cos(dec_sun*math.pi/180)
                          *math.cos(31.9614929*math.pi/180)
                          *math.cos(ha_sun*math.pi/180)))*(180/math.pi)
-    
-    #print("alt_sun = " + str(alt_sun))
-    
-    #sun_altaz = pos_sun.transform_to(AltAz(obstime=tobs,location=kitt_peak))
-    
-    #print sun_altaz
-    
-    #alt_sun = sun_altaz.alt.value
-    
-    #print alt_sun
     
     #Print warning if the Sun is up. We may decide this should do more than just warn
     if (alt_sun >=-30):
@@ -215,6 +176,10 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
         
     mindec = 100.0
     nextfield = 0
+    
+    #- Perform coarse trim of tiles with mismatched coordinates
+    igood = np.where( (last-25 <= tiles_array['RA']) & (tiles_array['RA'] <= last+25) )[0]
+    tiles_array = tiles_array[igood]
     
     #- Setup astropy SkyCoord objects
     tiles = SkyCoord(ra=tiles_array['RA']*u.deg, dec=tiles_array['DEC']*u.deg, frame='icrs')
@@ -238,10 +203,7 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
     #- will need to explicitly handle the case of running out of tiles later
     assert len(tiles_array) > 0
         
-    #- shorthand
-    #ra = tiles_array['RA']
-    #dec = tiles_array['DEC']
-    
+    #- shorthand    
     ra = tiles.ra.value
     dec = tiles.dec.value
 

--- a/py/desisurvey/nextfield.py
+++ b/py/desisurvey/nextfield.py
@@ -99,7 +99,7 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
         used for testing purposes. 
     """
                 
-    tobs = Time(dateobs, format='jd', scale='utc')
+    tobs = Time(dateobs, format='jd', scale='ut1')
     #kitt_peak = EarthLocation(lat=31.9634*u.deg, lon=-111.6003*u.deg, height=2120*u.m)
     #kitt_peak_long = Longitude(-111.5984796*u.deg)
     #iers.IERS.iers_table = iers.IERS_A.open('finals2000A.all.txt')
@@ -246,10 +246,21 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
 
     #- will need to explicitly handle the case of running out of tiles later
     assert len(tiles_array) > 0
+    
+    #- Determine the current epoch from the input date and store as string
+    epoch = "J" + str(round(tobs.decimalyear, 3))
         
     #- shorthand
     ra = tiles_array['RA']
     dec = tiles_array['DEC']
+    
+    #- Setup astropy SkyCoord objects
+    tiles = SkyCoord(ra=ra*u.deg, dec=dec*u.deg, frame='icrs')
+    
+    #- Transform the RA and Dec to JNow right the transformed data back to the shorthand
+    tiles = tiles.transform_to(FK5(equinox=epoch))
+    ra = tiles.ra.value
+    dec = tiles.dec.value
 
     #- calculate the hour angle for those tiles
     ha = (last - ra + 360) % 360

--- a/py/desisurvey/nextfield.py
+++ b/py/desisurvey/nextfield.py
@@ -216,28 +216,19 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
     mindec = 100.0
     nextfield = 0
     
+    #- Setup astropy SkyCoord objects
+    tiles = SkyCoord(ra=tiles_array['RA']*u.deg, dec=tiles_array['DEC']*u.deg, frame='icrs')
     
-    #Read the data from the file and find the next field
-    # for i in range(0,len(tiles_array)):
-    #     if (tiles_array[i]['RA'] >= last-15 and tiles_array[i]['RA'] <= last+15):
-    #         ha = last-tiles_array[i]['RA']
-    #         if ha < 0:
-    #             ha = ha + 360
-    #         if ha > 360:
-    #             ha = ha - 360
-    #         alt = (math.asin(math.sin(tiles_array[i]['DEC']*math.pi/180)
-    #                          *math.sin(31.9614929*math.pi/180)
-    #                          +math.cos(tiles_array[i]['DEC']*math.pi/180)
-    #                          *math.cos(31.9614929*math.pi/180)
-    #                          *math.cos(ha*math.pi/180)))*(180/math.pi)
-    #         if (alt >= 0 and tiles_array[i]['DEC'] < mindec):
-    #             mindec = tiles_array[i]['DEC']
-    #             #nextfield = tiles_array[i]['TILEID']
-    #             nextfield = i
+    #- Determine the current epoch from the input date and store as string
+    epoch = "J" + str(round(tobs.decimalyear, 3))
+    
+    #- Transform the RA and Dec to JNow right the transformed data back to the shorthand
+    tiles = tiles.transform_to(FK5(equinox=epoch))
 
     #- Trim tiles_array to those within 15 degrees of the meridian
-    igood = np.where( (last-15 <= tiles_array['RA']) & (tiles_array['RA'] <= last+15) )[0]
+    igood = np.where( (last-15 <= tiles.ra.value) & (tiles.ra.value <= last+15) )[0]
     tiles_array = tiles_array[igood]
+    tiles = tiles[igood]
     
     #- Remove previously observed tiles
     notobs = np.in1d(tiles_array['TILEID'], previoustiles, invert=True)
@@ -246,19 +237,11 @@ def get_next_field(dateobs, skylevel, seeing, transparency, previoustiles,
 
     #- will need to explicitly handle the case of running out of tiles later
     assert len(tiles_array) > 0
-    
-    #- Determine the current epoch from the input date and store as string
-    epoch = "J" + str(round(tobs.decimalyear, 3))
         
     #- shorthand
-    ra = tiles_array['RA']
-    dec = tiles_array['DEC']
+    #ra = tiles_array['RA']
+    #dec = tiles_array['DEC']
     
-    #- Setup astropy SkyCoord objects
-    tiles = SkyCoord(ra=ra*u.deg, dec=dec*u.deg, frame='icrs')
-    
-    #- Transform the RA and Dec to JNow right the transformed data back to the shorthand
-    tiles = tiles.transform_to(FK5(equinox=epoch))
     ra = tiles.ra.value
     dec = tiles.dec.value
 

--- a/py/desisurvey/nextfield.py
+++ b/py/desisurvey/nextfield.py
@@ -251,14 +251,14 @@ purposes of optimizing."""
         
             
 
-#dateobs = float(raw_input('Enter the date of observation: '))
-#skylevel = 0
-#seeing = 0.0
-#transparency = 0
-#previoustiles = [23492, 943, 6705]
-#programname = 'DESI'
-#start_time = time.time()
-#next_field = get_next_field(dateobs, skylevel, seeing, transparency, previoustiles, programname)
+dateobs = float(raw_input('Enter the date of observation: '))
+skylevel = 0
+seeing = 0.0
+transparency = 0
+previoustiles = [23492, 943, 6705]
+programname = 'DESI'
+start_time = time.time()
+next_field = get_next_field(dateobs, skylevel, seeing, transparency, previoustiles, programname)
 
-#print("Total execution time: %s seconds" % (time.time()-start_time))
-#print next_field
+print("Total execution time: %s seconds" % (time.time()-start_time))
+print next_field

--- a/py/desisurvey/nextfield.py
+++ b/py/desisurvey/nextfield.py
@@ -251,14 +251,14 @@ purposes of optimizing."""
         
             
 
-dateobs = float(raw_input('Enter the date of observation: '))
-skylevel = 0
-seeing = 0.0
-transparency = 0
-previoustiles = [23492, 943, 6705]
-programname = 'DESI'
-start_time = time.time()
-next_field = get_next_field(dateobs, skylevel, seeing, transparency, previoustiles, programname)
+#dateobs = float(raw_input('Enter the date of observation: '))
+#skylevel = 0
+#seeing = 0.0
+#transparency = 0
+#previoustiles = [23492, 943, 6705]
+#programname = 'DESI'
+#start_time = time.time()
+#next_field = get_next_field(dateobs, skylevel, seeing, transparency, previoustiles, programname)
 
-print("Total execution time: %s seconds" % (time.time()-start_time))
-print next_field
+#print("Total execution time: %s seconds" % (time.time()-start_time))
+#print next_field

--- a/py/desisurvey/test/test_nextfield.py
+++ b/py/desisurvey/test/test_nextfield.py
@@ -61,7 +61,7 @@ class TestNextField(unittest.TestCase):
         the rightanswer array were found by hand to be the 'correct' answer (i.e the tile
         with the minimum declination, within +/- 15 degrees of the meridian.
         """
-        rightanswer = [23492, 28072, 14976, 2435, 3784, 120, 316, 2110, 23492, 28072]
+        rightanswer = [23492, 28072, 26499, 2435, 26832, 11522, 23364, 25159, 23492, 28072]
         for test in range(10):
             next_field = get_next_field(2458728.708 + 137.0*test, self.skylevel, self.seeing, \
                 self.transparency, self.previoustiles, self.programname)


### PR DESCRIPTION
Updated the code to ensure that coordinates used are consistent with the local sidereal time coordinates. Updated the expected answers for test_rightanswer as the right answer did change slightly (old right answers were still close). The code performs a coarse trim of the tiles prior to coordinate transform for a slight performance increase. After the coordinate transform (which is only internal so the output tile coordinates are still J2000) the code performs all trimming based on separation from the meridian and altitude using the coordinates of the current epoch.