### PR TITLE
fix YEARMDD vs. MJD of sunset

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desisurvey change log
 ------------------
 
 * Add unit tests; fix afternoon planning tile updates and other minor bugs
+* Fix off-by-one with YEARMMDD vs. MJD of sunset
 
 0.3.1 (2016-12-21)
 ------------------

--- a/py/desisurvey/nightcal.py
+++ b/py/desisurvey/nightcal.py
@@ -66,23 +66,23 @@ def getCalAll(startdate, enddate, num_moon_steps=32,
         row = data[day_offset]
         # Calculate sun rise/set with different horizons.
         mayall.horizon = '-0:34' # the value that the USNO uses.
-        row['MJDsunset'] = mayall.next_setting(ephem.Sun()) + mjd0
-        row['MJDsunrise'] = mayall.next_rising(ephem.Sun()) + mjd0
+        row['MJDsunset'] = Time(mayall.next_setting(ephem.Sun()).datetime()).mjd
+        row['MJDsunrise'] = Time(mayall.next_rising(ephem.Sun()).datetime()).mjd
         # 13 deg twilight, adequate (?) for BGS sample.
         mayall.horizon = '-13'
-        row['MJDe13twi'] = mayall.next_setting(ephem.Sun(), use_center=True) + mjd0
-        row['MJDm13twi'] = mayall.next_rising(ephem.Sun(), use_center=True) + mjd0
+        row['MJDe13twi'] = Time(mayall.next_setting(ephem.Sun(), use_center=True).datetime()).mjd
+        row['MJDm13twi'] = Time(mayall.next_rising(ephem.Sun(), use_center=True).datetime()).mjd
         # 15 deg twilight, start of dark time if the moon is down.
         mayall.horizon = '-15'
-        row['MJDetwi'] = mayall.next_setting(ephem.Sun(), use_center=True) + mjd0
-        row['MJDmtwi'] = mayall.next_rising(ephem.Sun(), use_center=True) + mjd0
+        row['MJDetwi'] = Time(mayall.next_setting(ephem.Sun(), use_center=True).datetime()).mjd
+        row['MJDmtwi'] = Time(mayall.next_rising(ephem.Sun(), use_center=True).datetime()).mjd
         # Moon.
         mayall.horizon = '-0:34' # the value that the USNO uses.
-        row['MJDmoonrise'] = mayall.next_rising(ephem.Moon()) + mjd0
+        row['MJDmoonrise'] = Time(mayall.next_rising(ephem.Moon()).datetime()).mjd
         if row['MJDmoonrise'] > row['MJDsunrise']:
-            row['MJDmoonrise'] = mayall.previous_rising(ephem.Moon()) + mjd0
-        mayall.date = row['MJDmoonrise'] - mjd0
-        row['MJDmoonset'] = mayall.next_setting(ephem.Moon()) + mjd0
+            row['MJDmoonrise'] = Time(mayall.previous_rising(ephem.Moon()).datetime()).mjd
+        mayall.date = Time(row['MJDmoonrise'], format='mjd').to_datetime()
+        row['MJDmoonset'] = Time(mayall.next_setting(ephem.Moon()).datetime()).mjd
         # Calculate moon phase at the midpoint between sunset and sunrise.
         m0 = ephem.Moon()
         m0.compute(0.5 * (row['MJDsunset'] + row['MJDsunrise']) - mjd0)

--- a/py/desisurvey/test/test_nightcal.py
+++ b/py/desisurvey/test/test_nightcal.py
@@ -5,6 +5,7 @@ import uuid
 import numpy as np
 from desisurvey.nightcal import getCalAll
 from astropy.time import Time
+from astropy import units
 
 class TestNightCal(unittest.TestCase):
     
@@ -23,10 +24,11 @@ class TestNightCal(unittest.TestCase):
             shutil.rmtree(cls.testdir)            
             
     def test_getcal(self):
-        start = Time('2019-09-01T00:00:00')
-        end = Time('2019-10-01T00:00:00')
+        #- Start at 19:00 UTC = noon Arizona
+        start = Time('2019-09-01T19:00:00')
+        end = Time('2019-10-01T19:00:00')
         ephem = getCalAll(start, end, use_cache=False)
-        
+
         self.assertEqual(len(ephem), 31)
         self.assertTrue(np.all(ephem['MJDsunrise'] > ephem['MJDsunset']))
         self.assertTrue(np.all(ephem['MJDetwi'] > ephem['MJDe13twi']))
@@ -36,6 +38,21 @@ class TestNightCal(unittest.TestCase):
         self.assertLess(np.min(ephem['MoonFrac']), 0.01)
         self.assertGreaterEqual(np.min(ephem['MoonFrac']), 0.00)
         self.assertTrue(np.all(ephem['MJDmoonrise'] < ephem['MJDmoonset']))
+
+        for x in ephem:
+            night = x['dirName'].decode('ascii')
+
+            for key in [
+                    'MJDsunset', 'MJDsunrise',
+                    'MJDe13twi', 'MJDm13twi',
+                    'MJDetwi', 'MJDmtwi',
+                ]:
+                #- AZ local time
+                localtime = Time(x[key], format='mjd') - 7*units.hour
+                #- YEARMMDD of sunset for that time
+                yearmmdd = (localtime - 12*units.hour).to_datetime().strftime('%Y%m%d')
+                msg = '{} != {} for {}={}'.format(night, yearmmdd, key, x[key])
+                self.assertEqual(night, yearmmdd, msg)
                 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes an off-by-one bug in the YEARMMDD vs. MJD of the sunset, originally discovered with code like this:
```python
from desisurvey.nightcal import getCalAll
from astropy.time import Time
from astropy import units

#- 19:00 UTC is noon Arizona
start = Time('2019-09-01T19:00:00')
end = Time('2019-10-01T19:00:00')
ephem = getCalAll(start, end, use_cache=False)

#- AZ local time of sunset
t = Time(ephem['MJDsunset'][0], format='mjd') - 7*units.hour
print(t.to_datetime(), 'vs', ephem['dirName'][0])
```
Which results in:
```
2019-09-02 18:50:34.175709 vs b'20190901'
```
Note: September 2 vs. September 1, i.e. the MJD of the sunset is being reported for the next day, not the current day.

I didn't fully discover why the original code didn't work, but this fix uses time conversions like
```python
row['MJDsunset'] = Time(mayall.next_setting(ephem.Sun()).datetime()).mjd
```
This PR includes unit tests that check the consistency of the MJD for the sunset, sunrise, and twilights compared to the YEARMMDD dirname in the ephemeris.  These test fail on current master and pass with this fix.