### PR TITLE
Fixed Az computation.

### DIFF
--- a/py/desisurvey/exposurecalc.py
+++ b/py/desisurvey/exposurecalc.py
@@ -137,6 +137,7 @@ def airMassCalculator(ra, dec, lst, return_altaz=False):
     """
     Calculates airmass given position and LST.  Uses formula from
     Rosenberg (1966) which is valid for small to moderate angles.
+    Defaults to value at horizon if object below the horizon.
 
     Args:
         ra: float (degrees)
@@ -150,12 +151,15 @@ def airMassCalculator(ra, dec, lst, return_altaz=False):
     Alt, Az = radec2altaz(ra, dec, lst)
     cosZ = np.cos(np.radians(90.0-Alt))
     if isinstance(Alt, np.ndarray):
-        amass = np.full(len(Alt), 1.0e99, dtype='f8')
-        amass[np.where(Alt>0.0)] = 1.0/(cosZ + 0.025*np.exp(-11.0*cosZ))
+        amass = np.full(len(Alt), 40.0, dtype='f8')
+        ii = np.where(Alt>0.0)
+        amass[ii] = 1.0/(cosZ[ii] + 0.025*np.exp(-11.0*cosZ[ii]))
     else:
         if Alt > 0.0:
             amass = 1.0/(cosZ + 0.025*np.exp(-11.0*cosZ))
         else:
-            amass = 1.0e99
+            amass = 40.0
+            
+    assert( np.all((amass <= 40.0) & (amass > 0.0)) )
 
     return (amass, Alt, Az) if return_altaz else amass

--- a/py/desisurvey/test/test_utils.py
+++ b/py/desisurvey/test/test_utils.py
@@ -36,5 +36,25 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(utils.angsep(0,20,0,10), 10.0)
         self.assertAlmostEqual(utils.angsep(60,70,60,50), 20.0)
 
+    def test_radec2altaz(self):
+        # Test against astropy SkyCoord and AltAz
+        LST = 91.74715323341904  # 2017-04-15 00:00:00 at KPNO according to astropy.time
+
+        ra, dec, lst = LST, 60, LST
+        alt, az = utils.radec2altaz(ra, dec, lst)
+        self.assertAlmostEqual(alt, 61.96451022, 0)
+        self.assertAlmostEqual(az, 0.406365, 0) # I don't get this value, it should be 0
+
+        ra, dec, lst = 150, 20, LST
+        alt, az = utils.radec2altaz(ra, dec, lst)
+        self.assertAlmostEqual(alt, 36.66732297, 0)
+        self.assertAlmostEqual(az, 87.93562759, 0)
+
+        ra, dec, lst = 0, 45, LST
+        alt, az = utils.radec2altaz(ra, dec, lst)
+        self.assertAlmostEqual(alt, 21.03485612, 0)
+        self.assertAlmostEqual(az, 310.87827568, 0)
+        
+
 if __name__ == '__main__':
     unittest.main()

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -103,6 +103,14 @@ def radec2altaz(ra, dec, lst):
             sinAlt = -1.0
     cosAlt = np.sqrt(1.0-sinAlt*sinAlt)
     cosAz = ( np.sin(d) - sinAlt*np.sin(phi) ) / ( cosAlt*np.cos(phi) )
+    if isinstance(cosAz, np.ndarray):
+        cosAz[np.where(cosAz>1.0)] = 1.0
+        cosAz[np.where(cosAz<-1.0)] = -1.0
+    else:
+        if cosAz > 1.0:
+            cosAz = 1.0
+        if cosAz < -1.0:
+            cosAz = -1.0
 
     Alt = np.degrees(np.arcsin(sinAlt))
     Az = np.degrees(np.arccos(cosAz))

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -115,7 +115,8 @@ def radec2altaz(ra, dec, lst):
     Alt = np.degrees(np.arcsin(sinAlt))
     Az = np.degrees(np.arccos(cosAz))
     if isinstance(h, np.ndarray):
-        Az[np.where(np.sin(h)>0.0)] = 360.0 - Az
+        ii = np.where(np.sin(h)>0.0)
+        Az[ii] = 360.0 - Az[ii]
     else:
         if np.sin(h) > 0.0:
             Az = 360.0 - Az

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -87,10 +87,10 @@ def radec2altaz(ra, dec, lst):
     else:
         if h < 0.0:
             h += 2.0*np.pi
+
     d = np.radians(dec)
     phi = np.radians(mayall.lat_deg)
 
-    sinAz = np.sin(h) / (np.cos(h)*np.sin(phi) - np.tan(d)*np.cos(phi))
     sinAlt = np.sin(phi)*np.sin(d) + np.cos(phi)*np.cos(d)*np.cos(h)
 
     if isinstance(sinAlt, np.ndarray):
@@ -101,16 +101,18 @@ def radec2altaz(ra, dec, lst):
             sinAlt = 1.0
         if sinAlt < -1.0:
             sinAlt = -1.0
-    if isinstance(sinAz, np.ndarray):
-        sinAz[np.where(sinAz>1.0)] = 1.0
-        sinAz[np.where(sinAz<-1.0)] = -1.0
-    else:
-        if sinAz > 1.0:
-            sinAz = 1.0
-        if sinAz < -1.0:
-            sinAz = -1.0
+    cosAlt = np.sqrt(1.0-sinAlt*sinAlt)
+    cosAz = ( np.sin(d) - sinAlt*np.sin(phi) ) / ( cosAlt*np.cos(phi) )
 
-    return np.degrees(np.arcsin(sinAlt)), np.degrees(np.arcsin(sinAz))
+    Alt = np.degrees(np.arcsin(sinAlt))
+    Az = np.degrees(np.arccos(cosAz))
+    if isinstance(h, np.ndarray):
+        Az[np.where(np.sin(h)>0.0)] = 360.0 - Az
+    else:
+        if np.sin(h) > 0.0:
+            Az = 360.0 - Az
+
+    return Alt, Az
 
 def angsep(ra1, dec1, ra2, dec2):
     """
@@ -158,9 +160,10 @@ def equ2gal_J2000(ra_deg, dec_deg):
     l = np.arctan2(y[1], y[0])
 
     l_deg = np.degrees(l)
+    b_deg = np.degrees(b)
+
     if l_deg < 0.0:
         l_deg += 360.0
-    b_deg = np.degrees(b)
 
     return l_deg, b_deg
 


### PR DESCRIPTION
The (Ra,Dec) to (Alt, Az) computation had a bug when the Az was in some quadrant.  Now fixed and also corrected the standard convention with Az = [0, 360[ .