### PR TITLE
fix desisurvey unit tests

### DIFF
--- a/py/desisurvey/ephemerides.py
+++ b/py/desisurvey/ephemerides.py
@@ -502,7 +502,7 @@ def get_grid(step_size = 1 * u.min,
         Numpy array of dimensionless offsets relative to local midnight
         in units of days.
     """
-    num_points = int(round(((night_stop - night_start) / step_size).to(1)))
+    num_points = int(round(((night_stop - night_start) / step_size).to(1).value))
     night_stop = night_start + num_points * step_size
     return (night_start.to(u.day).value +
             step_size.to(u.day).value * np.arange(num_points + 1))

--- a/py/desisurvey/test/test_utils.py
+++ b/py/desisurvey/test/test_utils.py
@@ -75,7 +75,7 @@ class TestUtils(unittest.TestCase):
         t = astropy.time.Time('2020-01-01')
         with self.assertRaises(TypeError):
             utils.get_observer(t, alt=1, az=1)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(u.UnitsError):
             utils.get_observer(t, alt=1 * u.m, az=1 * u.m)
 
     def test_get_observer_time(self):


### PR DESCRIPTION
This PR fixes unit tests that were failing at NERSC and on my laptop.  @dkirkby please check on your setup because this might be indicative of some delicate dependencies issue.  I verified that it is *not* astropy 1.2 vs. 1.3.

ephemerides.py L505 was failing with
```
======================================================================
ERROR: test_planning (desisurvey.test.test_surveyplan.TestSurveyPlan)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/global/common/edison/contrib/desi/code/desisurvey/master/py/desisurvey/test/test_surveyplan.py", line 35, in test_planning
    ephem = Ephemerides(start, stop, use_cache=False, write_cache=False)
  File "/global/common/edison/contrib/desi/code/desisurvey/master/py/desisurvey/ephemerides.py", line 213, in __init__
    t_grid = get_grid(step_size=15 * u.s)
  File "/global/common/edison/contrib/desi/code/desisurvey/master/py/desisurvey/ephemerides.py", line 505, in get_grid
    num_points = int(round(((night_stop - night_start) / step_size).to(1)))
TypeError: type Quantity doesn't define __round__ method
```
while test_utils.py L78 was failing due to the code raising a astropy.units.UnitsError instead of a TypeError.