### PR TITLE
Fixes one place where the ra=0/360 wraparound wasn't dealt with properly

### DIFF
--- a/py/desisurvey/nextobservation.py
+++ b/py/desisurvey/nextobservation.py
@@ -16,6 +16,7 @@ import desiutil.log
 
 import desisurvey.avoidobject
 import desisurvey.utils
+from desisurvey.utils import inLSTwindow
 import desisurvey.config
 
 
@@ -109,7 +110,7 @@ def nextFieldSelector(obsplan, mjd, progress):
         if lst_midpoint >= 360:
             lst_midpoint -= 360
         # Skip tiles whose exposure midpoint falls outside their LST window.
-        if lst_midpoint < tmin[i] or lst_midpoint > tmax[i]:
+        if not inLSTwindow(lst_midpoint, tmin[i], tmax[i]):
             continue
         # Skip a tile that is currently too close to the horizon.
         if zenith_angles[i] > max_zenith_angle:

--- a/py/desisurvey/plots.py
+++ b/py/desisurvey/plots.py
@@ -24,7 +24,7 @@ def plot_sky_passes(ra, dec, passnum, z, clip_lo=None, clip_hi=None,
                     label='label', save=None):
     """Plot sky maps for each pass of a per-tile scalar quantity.
 
-    The matplotlib package must be installed to use this function.
+    The matplotlib and basemap packages must be installed to use this function.
 
     Parameters
     ----------
@@ -180,7 +180,7 @@ def plot_program(ephem, start_date=None, stop_date=None, style='localtime',
                  bg_color='lightblue', save=None):
     """Plot an overview of the DARK/GRAY/BRIGHT program.
 
-    The matplotlib package must be installed to use this function.
+    The matplotlib and basemap packages must be installed to use this function.
 
     Parameters
     ----------
@@ -387,7 +387,7 @@ def plot_next_field(date_string, obs_num, ephem, window_size=7.,
                     save=None):
     """Plot diagnostics for the next field selector.
 
-    The matplotlib package must be installed to use this function.
+    The matplotlib and basemap packages must be installed to use this function.
 
     Parameters
     ----------
@@ -578,7 +578,7 @@ def plot_planner(p, start_date=None, stop_date=None, where=None, when=None,
                  cmap='magma', save=None):
     """Plot a summary of the planner observing efficiency forecast.
 
-    Requires that the matplotlib package is installed.
+    Requires that the matplotlib and basemap packages are installed.
 
     Parameters
     ----------
@@ -828,7 +828,7 @@ def plot_iers(which='auto', num_points=500, save=None):
     This function is primarily intended to document and debug the
     :func:`desisurvey.utils.update_iers` and :func:`desisurvey.utils.freeze_iers` functions.
 
-    Requires that the matplotlib package is installed.
+    Requires that the matplotlib and basemap packages are installed.
 
     Parameters
     ----------


### PR DESCRIPTION
The changes in this PR make the results less wrong at the RA=0/360deg wraparound.  The gap where no observations are scheduled is mostly gone in the first pass of each program.

nextobservations.py: changed the condition on LST to use the utils.inLSTwindow() that checks for possible wraparound.

plots.py: amended the doc strings to specify that the basemap package has to be installed.
