### PR TITLE
remove sys.exit from afternoonplan; fix tests

### DIFF
--- a/py/desisurvey/afternoonplan.py
+++ b/py/desisurvey/afternoonplan.py
@@ -150,9 +150,6 @@ class surveyPlan:
         if len(self.tiles) != self.numtiles:
             raise RuntimeError('Missing some tiles in tile-info.fits')
 
-        import sys
-        sys.exit()
-
     def afternoonPlan(self, day_stats, progress):
         """Main decision making method.
 

--- a/py/desisurvey/test/test_surveyplan.py
+++ b/py/desisurvey/test/test_surveyplan.py
@@ -38,10 +38,10 @@ class TestSurveyPlan(unittest.TestCase):
 
         tiles = sp.tiles
         dLST = tiles['LSTMAX'] - tiles['LSTMIN']
-        wraparound = (dLST < -12)
-        dLST[wraparound] += 24
+        wraparound = (dLST < -180)
+        dLST[wraparound] += 360
         self.assertGreater(np.min(dLST), 0)
-        self.assertLess(np.max(dLST), 2)
+        self.assertLess(np.max(dLST), 30)
         self.assertTrue(np.all(tiles['EXPLEN'] > 500))
 
         #- Plan night 0; set the first 10 tiles as observed


### PR DESCRIPTION
This PR removes a spurious `sys.exit()` in `afternoonplan.surveyPlan.assignHA` and fixes a degrees vs. hours units bug in `test_surveyplan.py`.

More details:

There was a spurious `sys.exit()` at the end of `afternoonplan.surveyPlan.assignHA()`.  Oddly, standard "python setup.py test" tests did not catch this because apparently that causes the tests to exit rather than getting caught as an error.  However, surveysim tests using desisurvey did error, correctly noticing this as a SystemExit.  I don't know the structural difference.

Either way, removing the `sys.exit()` allowed all the tests to run, highlighting a different degrees vs. hours bug in test_surveyplan; this time the bug was in the test itself rather than the code.

After merging this we'll be back in a state where surveysim+desisurvey pass tests together on master.  Going via a PR to highlight the oddity of the impact of `sys.exit()` on the tests.  If someone wants to look into this after it gets merged, git hash f419509 was the state of master with the problem.