### PR TITLE
NERSC surveyplan

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisurvey change log
 0.8.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix flat vs. flatten for older versions of numpy
 
 0.8.1 (2017-06-19)
 ------------------

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -22,7 +22,8 @@ location:
 first_day: 2019-08-28
 
 # Survey nominally ends on morning of this date. Format is YYYY-MM-DD.
-last_day: 2024-07-13
+# last_day: 2024-07-13
+last_day: 2019-09-14
 
 # First night of monsoon shutdown is on this date each year.
 # Format is YYYY-MM-DD but the year is ignored.

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -22,8 +22,7 @@ location:
 first_day: 2019-08-28
 
 # Survey nominally ends on morning of this date. Format is YYYY-MM-DD.
-# last_day: 2024-07-13
-last_day: 2019-09-14
+last_day: 2024-07-13
 
 # First night of monsoon shutdown is on this date each year.
 # Format is YYYY-MM-DD but the year is ignored.

--- a/py/desisurvey/optimize.py
+++ b/py/desisurvey/optimize.py
@@ -104,9 +104,9 @@ class Optimizer(object):
         dt = sched.step_size.to(u.hour).value
         wgt = dt * np.ones((sched.num_nights, sched.num_times))
         # Weight nights for weather availability.
-        lst = wrap(e['lst'][sel.flat], origin)
+        lst = wrap(e['lst'][sel.flatten()], origin)
         wgt *= sched.calendar['weather'][:, np.newaxis]
-        wgt = wgt[sel].flat
+        wgt = wgt[sel].flatten()
         self.lst_hist, self.lst_edges = np.histogram(
             lst, bins=nbins, range=(origin, origin + 360), weights=wgt)
         self.lst_centers = 0.5 * (self.lst_edges[1:] + self.lst_edges[:-1])
@@ -194,7 +194,7 @@ class Optimizer(object):
             MSE_min = np.inf
             for center in centers:
                 # Histogram LST values relative to the specified center.
-                lst = wrap(e['lst'][sel.flat], center)
+                lst = wrap(e['lst'][sel.flatten()], center)
                 hist, edges = np.histogram(
                     lst, bins=nbins, range=(center, center + 360), weights=wgt)
                 lst_cdf = np.zeros_like(edges)


### PR DESCRIPTION
Fixes indexing bug when using numpy 1.11 that was causing surveyplan to fail at NERSC.

Details: in older version of numpy, e.g. 1.11, indexing an array with a list of booleans behaved differently than with an array of booleans, e.g.
```
>>> import numpy as np
>>> x = np.arange(5)
>>> x[ [True, False, True, False, True] ]
__main__:1: FutureWarning: in the future, boolean array-likes will be handled as a boolean array index
array([1, 0, 1, 0, 1])
>>> x[ [1, 0, 1, 0, 1] ]
array([1, 0, 1, 0, 1])
>>> x[ np.array([True, False, True, False, True]) ]
array([0, 2, 4])
```
This is confusing and bad, and is fixed in recent versions of numpy so that lists of booleans are treated the same as arrays of booleans for indexing.

surveysim hit this problem when using `sel.flat` instead of `sel.flatten()`.  The former returns an iterator which gets treated like a list which ends up getting interpreted as a bunch of indices 0 or 1, while `sel.flatten()` returns an array of booleans, and subselects as intended on both newer and older versions of numpy.

Fixes #48 