### PR TITLE
add surveyplan --start/--stop; fix end-of-survey bug; EXTNAME

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desisurvey change log
 0.8.3 (unreleased)
 ------------------
 
-* No changes yet
+* Added surveyplan --start and --stop options
+* Added EXTNAMEs to output files
 
 0.8.2 (2017-07-12)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,8 @@ desisurvey change log
 
 * Added surveyplan --start and --stop options
 * Added EXTNAMEs to output files
+* Fix bug when tiles remain on last day of survey but exposures times will
+  extend beyond sunrise
 
 0.8.2 (2017-07-12)
 ------------------

--- a/py/desisurvey/ephemerides.py
+++ b/py/desisurvey/ephemerides.py
@@ -236,6 +236,7 @@ class Ephemerides(object):
 
         if write_cache:
             self.log.info('Saving ephemerides to {0}'.format(filename))
+            self._table.meta['EXTNAME'] = 'EPHEMERIS'
             self._table.write(filename, overwrite=True)
 
     def get_row(self, row_index):

--- a/py/desisurvey/progress.py
+++ b/py/desisurvey/progress.py
@@ -258,6 +258,7 @@ class Progress(object):
         """
         config = desisurvey.config.Configuration()
         filename = config.get_path(filename)
+        self._table.meta['EXTNAME'] = 'SURVEYPROGRESS'
         self._table.write(filename, overwrite=overwrite)
         self.log.info('Saved progress to {0}.'.format(filename))
 

--- a/py/desisurvey/schedule.py
+++ b/py/desisurvey/schedule.py
@@ -165,7 +165,7 @@ class Scheduler(object):
 
         Calculated as ``texp / (texp + toh) * eff`` where the exposure time
         ``texp`` accounts for the tile's remaining SNR**2 and the current
-        exposure-time factors, and the ovhead time ``toh`` accounts for
+        exposure-time factors, and the overhead time ``toh`` accounts for
         readout, slew, focus and cosmic splits.
 
         Parameters
@@ -447,6 +447,8 @@ class Scheduler(object):
         # and estimated exposure midpoints.
         ieff, toh, tmid, prev = self.instantaneous_efficiency(
             when, cutoff, seeing, transparency, progress, snr2frac, mask)
+        # Mask tiles with ieff=0.0 (e.g. because they extend beyond cutoff)
+        mask = mask & (ieff > 0)
         # Lookup the temporal bin index that each tile's estimated exposure
         # midpoint lands in.
         dt = when.mjd - desisurvey.utils.local_noon_on_date(night).mjd - 0.5

--- a/py/desisurvey/scripts/surveyplan.py
+++ b/py/desisurvey/scripts/surveyplan.py
@@ -35,6 +35,12 @@ def parse(options=None):
     parser.add_argument(
         '--create', action='store_true', help='create an initial plan')
     parser.add_argument(
+        '--start', type=str, default=None, metavar='DATE',
+        help='plan starts on the evening of this day, formatted as YYYY-MM-DD')
+    parser.add_argument(
+        '--stop', type=str, default=None, metavar='DATE',
+        help='plan stops on the morning of this day, formatted as YYYY-MM-DD')
+    parser.add_argument(
         '--duration', type=int, metavar='DAYS', default=None,
         help='duration of plan in days (or plan rest of the survey)')
     parser.add_argument(
@@ -74,6 +80,12 @@ def main(args):
     config = desisurvey.config.Configuration()
     if args.output_path is not None:
         config.set_output_path(args.output_path)
+
+    if args.start is not None:
+        config.first_day._value = desisurvey.utils.get_date(args.start)
+
+    if args.stop is not None:
+        config.last_day._value = desisurvey.utils.get_date(args.stop)
 
     # Tabulate emphemerides if necessary.
     ephem = desisurvey.ephemerides.Ephemerides()
@@ -140,5 +152,6 @@ def main(args):
         sys.exit(9)
 
     # Save the plan and a backup.
+    plan.meta['EXTNAME'] = 'SURVEYPLAN'
     plan.write(config.get_path('plan.fits'), overwrite=True)
     plan.write(config.get_path('plan_{0}.fits'.format(start)), overwrite=True)


### PR DESCRIPTION
This PR fixes #50 by adding `--start` and `--stop` options to surveyplan, following the conventions of `surveysim` where "stop" means "stop on the morning of that date".

It also fixes a `Scheduler.next_tile` bug that occurred when there were tiles left on the last night of the survey but their predicted exposure times all exceeded the cutoff.

I also added EXTNAME keywords to output file HDUs, but for now did not force readers to use that EXTNAME in order to be backwards compatible with any survey files already written.