### PR TITLE
Support either str/bytes column dtype

### DIFF
--- a/py/desisurvey/test/test_progress.py
+++ b/py/desisurvey/test/test_progress.py
@@ -111,7 +111,11 @@ class TestProgress(unittest.TestCase):
         explist = p.get_exposures(exp_fields='mjd,night')
         for row in explist:
             night = str(desisurvey.utils.get_date(row['mjd']))
-            self.assertEqual(row['night'], night)
+            try:
+                self.assertEqual(row['night'], night)
+            except AssertionError:
+                # Necessary if column dtype is bytes.
+                self.assertEqual(row['night'].decode(), night)
             self.assertEqual(night, str(desisurvey.utils.get_date(night)))
 
     def test_exposures_incrementing(self):


### PR DESCRIPTION
Hotfix for unit test failure under py 3.5 and astropy 1.x (I suspect that astropy 1.x is the cause, not py 3.5).