### PR TITLE
use desimodel.footprint.pass2program if available

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -9,8 +9,8 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
-* Neither the name of the Astropy Team nor the names of its contributors may be
-  used to endorse or promote products derived from
+* Neither the name of the DESI Collaboration nor the names of its contributors
+  may be used to endorse or promote products derived from
   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisurvey change log
 0.9.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Progress.get_exposures() uses desimodel.footprint.pass2program if available.
 
 0.9.3 (2017-10-09)
 ------------------

--- a/py/desisurvey/progress.py
+++ b/py/desisurvey/progress.py
@@ -592,10 +592,17 @@ class Progress(object):
                     description='Apparent local sidereal time in degrees')
             elif name == 'program':
                 exppass = table['pass'][tile_index]
-                program = np.empty(len(exppass), dtype='S6')
-                program[:] = 'BRIGHT'
-                program[exppass < 4] = 'DARK'
-                program[exppass == 4] = 'GRAY'
+                try:
+                    from desimodel.footprint import pass2program
+                    program = pass2program(exppass)
+                except ImportError:
+                    #- desimodel < 0.9.1 doesn't have pass2program, so
+                    #- hardcode the mapping that it did have
+                    program = np.empty(len(exppass), dtype='S6')
+                    program[:] = 'BRIGHT'
+                    program[exppass < 4] = 'DARK'
+                    program[exppass == 4] = 'GRAY'
+
                 output[name.upper()] = astropy.table.Column(program,
                                                             description='Program name')
             elif name == 'expid':

--- a/py/desisurvey/progress.py
+++ b/py/desisurvey/progress.py
@@ -576,7 +576,7 @@ class Progress(object):
                     description='Cummulative fraction of target S/N**2')
             elif name == 'night':
                 mjd = table['mjd'].flatten()[order]
-                night = np.empty(len(mjd), dtype='S8')
+                night = np.empty(len(mjd), dtype=(str, 8))
                 for i in range(len(mjd)):
                     night[i] = str(desisurvey.utils.get_date(mjd[i])).replace('-', '')
                 output[name.upper()] = astropy.table.Column(
@@ -598,7 +598,7 @@ class Progress(object):
                 except ImportError:
                     #- desimodel < 0.9.1 doesn't have pass2program, so
                     #- hardcode the mapping that it did have
-                    program = np.empty(len(exppass), dtype='S6')
+                    program = np.empty(len(exppass), dtype=(str, 6))
                     program[:] = 'BRIGHT'
                     program[exppass < 4] = 'DARK'
                     program[exppass == 4] = 'GRAY'


### PR DESCRIPTION
This PR is a followup to #67, which hardcoded the tile pass -> program mapping since desimodel didn't provide that directly.  In the meantime, desihub/desimodel#67 adds `desimodel.footprint.pass2program` to do this based upon the desi-tiles.fits tile definition file.

This PR uses `desimodel.footprint.pass2program` if available (i.e. desimodel >= 0.9.1 is installed), and defaults to the previous hardcoded mapping since that is still valid for desimodel < 0.9.1.  If we never change the mapping, then this won't matter.  But if we do, now we just have to change the desimodel desi-tiles.fits file and the correct new mapping with automatically be used.