### PR TITLE
Add EXTNAME Keyword

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisurvey change log
 0.10.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Set the ``EXTNAME`` keyword on the Table returned by ``Progress.get_exposures()``.
 
 0.10.0 (2017-11-09)
 -------------------

--- a/py/desisurvey/progress.py
+++ b/py/desisurvey/progress.py
@@ -550,6 +550,7 @@ class Progress(object):
         # Create the output table.
         tileinfo = None
         output = astropy.table.Table()
+        output.meta['EXTNAME'] = 'EXPOSURES'
         for name in tile_fields.split(','):
             name = name.lower()
             if name == 'index':

--- a/py/desisurvey/test/test_progress.py
+++ b/py/desisurvey/test/test_progress.py
@@ -98,6 +98,7 @@ class TestProgress(unittest.TestCase):
             p.add_exposure(
                 tile_id, t0 + i * u.hour, 1e3 * u.s, 0.5, 1.5, 1.1, 1, 0, 0, 0)
         explist = p.get_exposures()
+        self.assertEqual(explist.meta['EXTNAME'], 'EXPOSURES')
         self.assertTrue(np.all(np.diff(explist['MJD']) > 0))
         explist = p.get_exposures(tile_fields='index', exp_fields='lst')
         self.assertTrue(np.all(np.diff(explist['LST']) > 0))
@@ -121,6 +122,7 @@ class TestProgress(unittest.TestCase):
         explist.write(expfile)
         newexp = Table.read(expfile)
 
+        self.assertEqual(newexp.meta['EXTNAME'], 'EXPOSURES')
         self.assertEqual(explist['PROGRAM'].dtype, newexp['PROGRAM'].dtype)
         self.assertEqual(explist['NIGHT'].dtype, newexp['NIGHT'].dtype)
         self.assertTrue(np.all(explist['PROGRAM'] == newexp['PROGRAM']))


### PR DESCRIPTION
This PR sets the `EXTNAME` keyword on the table returned by `Progress.get_exposures()`.