### PR TITLE
do not assume that input tile file includes all of DARK, BRIGHT, and GRAY tiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=1.3.3
         - SPHINX_VERSION=1.5
-        - DESIUTIL_VERSION=1.9.6
+        - DESIUTIL_VERSION=1.9.9
         - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=v0.9
         # - SPECTER_VERSION=0.6.0

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desisurvey change log
 0.10.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Do not assume that input tile file includes all of DARK, BRIGHT, and GRAY
+  tiles (PR `#83`_). 
+
+.. _`#83`: https://github.com/desihub/desisurvey/pull/83
 
 0.10.1 (2017-12-20)
 -------------------

--- a/py/desisurvey/scripts/surveymovie.py
+++ b/py/desisurvey/scripts/surveymovie.py
@@ -152,15 +152,15 @@ class Animator(object):
             start, stop, tile_fields='tileid,index,ra,dec,pass',
             exp_fields='expid,mjd,night,exptime,snr2cum,seeing,transparency')
         self.num_exp = len(self.exposures)
-        self.num_nights = len(np.unique(self.exposures['night']))
+        self.num_nights = len(np.unique(self.exposures['NIGHT']))
 
         # Calculate each exposure's LST window.
         exp_midpt = astropy.time.Time(
-            self.exposures['mjd'] + self.exposures['exptime'] / 86400.,
+            self.exposures['MJD'] + self.exposures['EXPTIME'] / 86400.,
             format='mjd', location=desisurvey.utils.get_location())
         lst_midpt = exp_midpt.sidereal_time('apparent').to(u.deg).value
         # convert from seconds to degrees.
-        lst_len = self.exposures['exptime'] / 240.
+        lst_len = self.exposures['EXPTIME'] / 240.
         self.lst = np.empty((self.num_exp, 2))
         self.lst[:, 0] = wrap(lst_midpt - 0.5 * lst_len)
         self.lst[:, 1] = wrap(lst_midpt + 0.5 * lst_len)
@@ -326,7 +326,7 @@ class Animator(object):
                 hdus.close()
                 # Save index of first exposure on this date.
                 noon = desisurvey.utils.local_noon_on_date(date)
-                self.iexp0 = np.argmax(self.exposures['mjd'] > noon.mjd)
+                self.iexp0 = np.argmax(self.exposures['MJD'] > noon.mjd)
             else:
                 self.warn('Missing scores file: {0}.'.format(scores_name))
         # Get interpolator for moon, planet positions during this night.
@@ -485,7 +485,7 @@ def main(args):
     animator.init_figure(args.nightly)
 
     if args.expid is not None:
-        expid = animator.exposures['expid']
+        expid = animator.exposures['EXPID']
         assert np.all(expid == expid[0] + np.arange(len(expid)))
         if (args.expid < expid[0]) or (args.expid > expid[-1]):
             raise RuntimeError('Requested exposure ID {0} not available.'


### PR DESCRIPTION
The changes in this simple PR are to accommodate the SV Data Challenge.  

`surveyinit` currently assumes that the tile file includes a mixture of DARK, BRIGHT, and GRAY tiles, and crashed when I gave it a minimal tile file with just DARK tiles, and so I added a simple `if` statement to check.

The second change (to `surveymovie`) was to use uppercase column names when grabbing data from the `exposures.fits` file (which perhaps was standardized elsewhere / previously?).