### PR TITLE
Increase tile radius slightly

### DIFF
--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -138,7 +138,7 @@ fiber_assignment_order:
     P7: P5+P6 delay 1
 
 # Nominal tile radius for determining whether two tiles overlap.
-tile_radius: 1.62 deg
+tile_radius: 1.63 deg
 
 #-------------------------------------------------------------------
 # Parameters to locate files needed by desisurvey.


### PR DESCRIPTION
desimodel.focalplane.get_tile_radius_deg() currently gives 1.6275 deg (0.9.10 master).  I think we'd rather err slightly on the high side than low side for these purposes.  My impression is that the change in primary mirror radius of curvature currently being discussed in commissioning will tweak this again, albeit only by a few arcseconds.