### PR TITLE
Add NFS/NTS interface to desisurvey scheduler

### DIFF
--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -3,7 +3,7 @@
 
   Based on our google sheet (
   these are the expected inputs
- 
+
         skylevel: current sky level [counts s-1 cm-2 arcsec-2]   (from ETC, at the end of last exposure)
         seeing: current atmospheric seeing PSF FWHM [arcsec]     (from ETC, at the end of last exposure)
         transparency: current atmospheric transparency [0-1, where 0=total cloud cover]   (from ETC, at the end of last exposure)
@@ -14,18 +14,18 @@
             EFS: this is currently not used.
         fiber_assign_dir: (output) directory for fiber assign files.
             EFS: this is currently not used for more than prepending to the tileid.
-        program (optional): request a tile will be in that program, 
+        program (optional): request a tile will be in that program,
                             otherwise get next field chooses program based on current conditions
 
         previoustiles (optional): list of tiles that have been observed that night (IS THIS RECORDED IN A FILE?)
-                                  This should be handled internally if at all possible. THe NTS could also scan the 
+                                  This should be handled internally if at all possible. THe NTS could also scan the
                                   fiber_assign_dir directory.
 
-  These variables are in the 
+  These variables are in the
         RA _prior:  in degrees, used only for user over-ride, defaults to -99
         DEC_prior:  in degrees, used only for user over-ride, defaults to -99
-            EFS: what is this?
-       
+            EFS: for slewing minimization; not used.
+
   If input values are missing (e.g. first exposure of the night), the NTS falls back to reasonable defaults for skylevel etc.
 
 
@@ -99,9 +99,8 @@ class NTS():
         # tileid, s2n, exptime, maxtime
 
         if mjd is None:
-            now = datetime.datetime.now()
             from astropy import time
-            mjd = time.Time(now).mjd
+            mjd = time.Time.now().mjd
             print('Warning: no time specified, using current time, MJD: %f' %
                   mjd)
         seeing = self.default_seeing if seeing is None else seeing
@@ -119,7 +118,6 @@ class NTS():
             mjd, self.ETC, seeing, transparency, skylevel, program=program)
         (tileid, passnum, snr2frac_start, exposure_factor, airmass,
          sched_program, mjd_program_end) = result
-        print(result)
         if tileid is None:
             return {'tileid': None, 's2n': 0., 'esttime': 0., 'maxtime': 0.,
                     'fiber_assign': '', 'foundtile': False}

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -172,7 +172,8 @@ def afternoon_plan(night=None, lastnight=None):
     # restore: maybe check directory, and restore if file present?  EFS
     # planner.save(), scheduler.save()
     # planner.restore(), scheduler.restore()
-    planner.afternoon_plan(datetime.date.fromisoformat(night),
+    import dateutil.parser
+    planner.afternoon_plan(dateutil.parser.parse(night).date(),
                            scheduler.completed)
     # currently afternoon planning checks to see what tiles have been marked
     # as done, and what new tiles may now be fiberassigned.

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -20,7 +20,6 @@
         previoustiles (optional): list of tiles that have been observed that night (IS THIS RECORDED IN A FILE?)
                                   This should be handled internally if at all possible. THe NTS could also scan the 
                                   fiber_assign_dir directory.
-            EFS: what is this for?
 
   These variables are in the 
         RA _prior:  in degrees, used only for user over-ride, defaults to -99
@@ -44,8 +43,6 @@
 """
 
 import os
-from shutil import copyfile
-from fitsio import *
 import desisurvey
 import desisurvey.rules
 import desisurvey.plan
@@ -53,10 +50,11 @@ import desisurvey.scheduler
 import desisurvey.etc
 import datetime
 
+
 class NTS():
-    def __init__(self, obsplan, fiber_assign_dir, defaults = {}, night=None):
-        """
-        The caller has checked that the obsplan file exists and that fiber_assign_dir is writable
+    def __init__(self, obsplan, fiber_assign_dir, defaults={}, night=None):
+        """The caller has checked that the obsplan file exists and that
+        fiber_assign_dir is writable
         """
         self.obsplan = obsplan
         self.fiber_assign_dir = fiber_assign_dir
@@ -65,30 +63,38 @@ class NTS():
         self.default_skylevel = defaults.get('skylevel', 1000.0)
         self.default_program = defaults.get('program', 'DESI DARK')
         if night is None:
-            print('Warning: no night selected, using current date!')  # EFS: warning, no night?
             self.night = datetime.date.today()
+            print('Warning: no night selected, using current date!',
+                  self.night)
         else:
             self.night = night
-        self.rules = desisurvey.rules.Rules()  # should look for rules file in obsplan dir?
-        self.planner = desisurvey.plan.Planner(self.rules)
-        self.scheduler = desisurvey.scheduler.Scheduler()
-        # restore: maybe check directory, and restore if file present?  EFS
-        # planner.save(), scheduler.save()
-        # planner.restore(), scheduler.restore()
-        self.planner.afternoon_plan(self.night, self.scheduler.completed)
-        self.scheduler.update_tiles(self.planner.tile_available, self.planner.tile_priority)
+        self.rules = desisurvey.rules.Rules()
+        # should look for rules file in obsplan dir?
+        try:
+            nightstr = self.night.isoformat()
+            self.planner = desisurvey.plan.Planner(
+                self.rules,
+                restore='planner_afternoon_{}.fits'.format(nightstr))
+            self.scheduler = desisurvey.scheduler.Scheduler(
+                restore='scheduler_{}.fits'.format(nightstr))
+        except:
+            raise ValueError('Error restoring scheduler & planner files; '
+                             'has afternoon planning been performed?')
+        self.scheduler.update_tiles(self.planner.tile_available,
+                                    self.planner.tile_priority)
         self.scheduler.init_night(self.night, use_twilight=True)
         self.ETC = desisurvey.etc.ExposureTimeCalculator()
-        
-        
 
-    def next_tile(self, mjd=None, skylevel = None, transparency = None, seeing = None, program = None, lastexp = None, fiber_assign = None):
+    def next_tile(self, mjd=None, skylevel=None, transparency=None,
+                  seeing=None, program=None, lastexp=None, fiber_assign=None,
+                  previoustiles=None):
         """
         select the next tile
         """
 
         if fiber_assign is not None:
-            raise ValueError('NTS: not sure what to do with fiberassign != None')  # EFS
+            raise ValueError('NTS: not sure what to do with '
+                             'fiberassign != None')  # EFS
 
         # tileid, s2n, exptime, maxtime
 
@@ -96,36 +102,100 @@ class NTS():
             now = datetime.datetime.now()
             from astropy import time
             mjd = time.Time(now).mjd
-            print('Warning: no time specified, using current time!')
+            print('Warning: no time specified, using current time, MJD: %f' %
+                  mjd)
         seeing = self.default_seeing if seeing is None else seeing
         skylevel = self.default_skylevel if skylevel is None else skylevel
-        transparency = self.default_transparency if transparency is None else transparency
+        transparency = (self.default_transparency if transparency is None
+                        else transparency)
 
+        if previoustiles is not None:
+            ind, mask = self.scheduler.tiles.index(previoustiles,
+                                                   return_mask=True)
+            self.scheduler.in_night_pool[ind[mask]] = False
+        # remove previous tiles from possible tiles to schedule
+        # note: this will be remembered until NTS is restarted!  EFS
         result = self.scheduler.next_tile(
             mjd, self.ETC, seeing, transparency, skylevel, program=program)
-        tileid, passnum, snr2frac_start, exposure_factor, airmass, sched_program, mjd_program_end = result
+        (tileid, passnum, snr2frac_start, exposure_factor, airmass,
+         sched_program, mjd_program_end) = result
         print(result)
         if tileid is None:
-            return {'tileid': None, 's2n': 0., 'esttime': 0., 'maxtime': 0., 'fiber_assign': '',
-                    'foundtile': False}
-            
+            return {'tileid': None, 's2n': 0., 'esttime': 0., 'maxtime': 0.,
+                    'fiber_assign': '', 'foundtile': False}
+
         # lastexp ignored, fiberassign ignored.  EFS
         texp_tot, texp_remaining, nexp_remaining = self.ETC.estimate_exposure(
             sched_program, snr2frac_start, exposure_factor, nexp_completed=0)
-        # s2n: this is really what we should be passing back, but currently scheduler thinks in terms of
-        # texp in 'nominal' conditions.  Want guidance converting this to s2n...
 
-        s2n = 50.0 * texp_remaining/(self.ETC.TEXP_TOTAL[sched_program]*exposure_factor)  # EFS hack
+        # s2n: this is really what we should be passing back, but currently
+        # scheduler thinks in terms of texp in 'nominal' conditions.  Want
+        # guidance converting this to s2n...
+        # what cosmic split related elements should I be thinking about here?
+
+        s2n = 50.0 * texp_remaining/(
+            self.ETC.TEXP_TOTAL[sched_program]*exposure_factor)  # EFS hack
         exptime = texp_remaining
         maxtime = self.ETC.MAX_EXPTIME
+        self.scheduler.update_snr(
+            tileid, snr2frac_start + min([exptime, maxtime])/texp_tot)
+        self.scheduler.save('scheduler_{}.fits'.format(self.night.isoformat()))
         if program is None:
             maxtime = min([maxtime, mjd_program_end-maxtime])
-        
-        fiber_assign = os.path.join(self.fiber_assign_dir, 'tile_%d.fits' % tileid)
+
+        fiber_assign = os.path.join(self.fiber_assign_dir,
+                                    'tile_%d.fits' % tileid)
         days_to_seconds = 60*60*24
 
-        selection = {'tileid' : tileid, 's2n' : s2n, 'esttime' : exptime*days_to_seconds,
-                     'maxtime' : maxtime*days_to_seconds, 'fiber_assign' : fiber_assign,
+        selection = {'tileid': tileid, 's2n': s2n,
+                     'esttime': exptime*days_to_seconds,
+                     'maxtime': maxtime*days_to_seconds,
+                     'fiber_assign': fiber_assign,
                      'foundtile': True}
 
         return selection
+
+
+def afternoon_plan(night=None, lastnight=None):
+    if night is None:
+        night = datetime.date.today().isoformat()
+    rules = desisurvey.rules.Rules()
+    # should look for rules file in obsplan dir?
+    if lastnight is not None:
+        planner = desisurvey.plan.Planner(
+            rules, restore='planner_end_{}.fits' % lastnight)
+        scheduler = desisurvey.scheduler.Scheduler(
+            restore='scheduler_end_{}.fits')
+    else:
+        planner = desisurvey.plan.Planner(rules)
+        scheduler = desisurvey.scheduler.Scheduler()
+    # restore: maybe check directory, and restore if file present?  EFS
+    # planner.save(), scheduler.save()
+    # planner.restore(), scheduler.restore()
+    planner.afternoon_plan(datetime.date.fromisoformat(night),
+                           scheduler.completed)
+    # currently afternoon planning checks to see what tiles have been marked
+    # as done, and what new tiles may now be fiberassigned.
+    # currently moves tiles closer to fiber assignment each time it's called
+    # (countdon decreases), depending on fiber_assign_cadence, etc.
+    # eventually we want this to be ~totally different, so while this isn't
+    # really the behavior we'd want on the mountain, I'm leaving it until
+    # we have something much different.
+    planner.save('planner_afternoon_{}.fits'.format(night))
+    scheduler.save('scheduler_{}.fits'.format(night))
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Perform afternoon planning.',
+        epilog='EXAMPLE: %(prog)s --night 2020-01-01')
+    parser.add_argument('--night', type=str,
+                        help='night to plan, default: tonight',
+                        default=None)
+    parser.add_argument('--lastnight', type=str,
+                        help='night to restore, default: start fresh.',
+                        default=None)
+
+    parser.parse_args()
+    afternoon_plan(parser.night, parser.lastnight)

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -1,0 +1,131 @@
+"""
+  Next Tile Selector
+
+  Based on our google sheet (
+  these are the expected inputs
+ 
+        skylevel: current sky level [counts s-1 cm-2 arcsec-2]   (from ETC, at the end of last exposure)
+        seeing: current atmospheric seeing PSF FWHM [arcsec]     (from ETC, at the end of last exposure)
+        transparency: current atmospheric transparency [0-1, where 0=total cloud cover]   (from ETC, at the end of last exposure)
+        lastexp:  completion time in UTC of most recent exposure
+            EFS: this is currently not used.
+
+        obsplan: filename containing that nights observing plan, defaults to planYEARMMDD.fits
+            EFS: this is currently not used.
+        fiber_assign_dir: (output) directory for fiber assign files.
+            EFS: this is currently not used for more than prepending to the tileid.
+        program (optional): request a tile will be in that program, 
+                            otherwise get next field chooses program based on current conditions
+
+        previoustiles (optional): list of tiles that have been observed that night (IS THIS RECORDED IN A FILE?)
+                                  This should be handled internally if at all possible. THe NTS could also scan the 
+                                  fiber_assign_dir directory.
+            EFS: what is this for?
+
+  These variables are in the 
+        RA _prior:  in degrees, used only for user over-ride, defaults to -99
+        DEC_prior:  in degrees, used only for user over-ride, defaults to -99
+            EFS: what is this?
+       
+  If input values are missing (e.g. first exposure of the night), the NTS falls back to reasonable defaults for skylevel etc.
+
+
+  The primary output of the NTS will be a dictionary with the name of the fiber assign file (full path)
+  The naming convention is tile_<tileid>.fits
+
+  In addition, the following keys/information is returned by the NTS:
+        tileid: (int) DESI Tile ID
+        s2n: (foat) Requested signal to noice (for ETC)
+        foundtile (boolean): indicates whether field selector was successful.
+        exptime: expected exposure time based on ETC information from previous exposure [seconds]
+        maxtime: maximum allowable exposure time [seconds]
+
+        Names are converted to FITS convention: TILEID, S2NREQ, EXTTIME, MAXTIME, FBRASSGN
+"""
+
+import os
+from shutil import copyfile
+from fitsio import *
+import desisurvey
+import desisurvey.rules
+import desisurvey.plan
+import desisurvey.scheduler
+import desisurvey.etc
+import datetime
+
+class NTS():
+    def __init__(self, obsplan, fiber_assign_dir, defaults = {}, night=None):
+        """
+        The caller has checked that the obsplan file exists and that fiber_assign_dir is writable
+        """
+        self.obsplan = obsplan
+        self.fiber_assign_dir = fiber_assign_dir
+        self.default_seeing = defaults.get('seeing', 1.0)
+        self.default_transparency = defaults.get('transparency', 0.9)
+        self.default_skylevel = defaults.get('skylevel', 1000.0)
+        self.default_program = defaults.get('program', 'DESI DARK')
+        if night is None:
+            print('Warning: no night selected, using current date!')  # EFS: warning, no night?
+            self.night = datetime.date.today()
+        else:
+            self.night = night
+        self.rules = desisurvey.rules.Rules()  # should look for rules file in obsplan dir?
+        self.planner = desisurvey.plan.Planner(self.rules)
+        self.scheduler = desisurvey.scheduler.Scheduler()
+        # restore: maybe check directory, and restore if file present?  EFS
+        # planner.save(), scheduler.save()
+        # planner.restore(), scheduler.restore()
+        self.planner.afternoon_plan(self.night, self.scheduler.completed)
+        self.scheduler.update_tiles(self.planner.tile_available, self.planner.tile_priority)
+        self.scheduler.init_night(self.night, use_twilight=True)
+        self.ETC = desisurvey.etc.ExposureTimeCalculator()
+        
+        
+
+    def next_tile(self, mjd=None, skylevel = None, transparency = None, seeing = None, program = None, lastexp = None, fiber_assign = None):
+        """
+        select the next tile
+        """
+
+        if fiber_assign is not None:
+            raise ValueError('NTS: not sure what to do with fiberassign != None')  # EFS
+
+        # tileid, s2n, exptime, maxtime
+
+        if mjd is None:
+            now = datetime.datetime.now()
+            from astropy import time
+            mjd = time.Time(now).mjd
+            print('Warning: no time specified, using current time!')
+        seeing = self.default_seeing if seeing is None else seeing
+        skylevel = self.default_skylevel if skylevel is None else skylevel
+        transparency = self.default_transparency if transparency is None else transparency
+
+        result = self.scheduler.next_tile(
+            mjd, self.ETC, seeing, transparency, skylevel, program=program)
+        tileid, passnum, snr2frac_start, exposure_factor, airmass, sched_program, mjd_program_end = result
+        print(result)
+        if tileid is None:
+            return {'tileid': None, 's2n': 0., 'esttime': 0., 'maxtime': 0., 'fiber_assign': '',
+                    'foundtile': False}
+            
+        # lastexp ignored, fiberassign ignored.  EFS
+        texp_tot, texp_remaining, nexp_remaining = self.ETC.estimate_exposure(
+            sched_program, snr2frac_start, exposure_factor, nexp_completed=0)
+        # s2n: this is really what we should be passing back, but currently scheduler thinks in terms of
+        # texp in 'nominal' conditions.  Want guidance converting this to s2n...
+
+        s2n = 50.0 * texp_remaining/(self.ETC.TEXP_TOTAL[sched_program]*exposure_factor)  # EFS hack
+        exptime = texp_remaining
+        maxtime = self.ETC.MAX_EXPTIME
+        if program is None:
+            maxtime = min([maxtime, mjd_program_end-maxtime])
+        
+        fiber_assign = os.path.join(self.fiber_assign_dir, 'tile_%d.fits' % tileid)
+        days_to_seconds = 60*60*24
+
+        selection = {'tileid' : tileid, 's2n' : s2n, 'esttime' : exptime*days_to_seconds,
+                     'maxtime' : maxtime*days_to_seconds, 'fiber_assign' : fiber_assign,
+                     'foundtile': True}
+
+        return selection

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -199,7 +199,8 @@ class Planner(object):
         t['COUNTDOWN'] = self.tile_countdown
         t['AVAILABLE'] = self.tile_available
         t['PRIORITY'] = self.tile_priority
-        t.write(fullname, overwrite=True)
+        t.write(fullname+'.tmp', overwrite=True, format='fits')
+        os.rename(fullname+'.tmp', fullname)
         self.log.debug(
             'Saved plan with {} ({}) / {} tiles covered (available) to "{}".'
             .format(np.count_nonzero(self.tile_covered),

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -137,7 +137,8 @@ class Scheduler(object):
         # Record the number of completed tiles.
         hdr['NDONE'] = self.completed_by_pass.sum()
         # Save a copy of our snr2frac array.
-        astropy.io.fits.PrimaryHDU(self.snr2frac, header=hdr).writeto(fullname, overwrite=True)
+        astropy.io.fits.PrimaryHDU(self.snr2frac, header=hdr).writeto(fullname+'.tmp', overwrite=True)
+        os.rename(fullname+'.tmp', fullname)
         self.log.debug('Saved scheduler snapshot to "{}".'.format(fullname))
 
     def update_tiles(self, tile_available, tile_priority):

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -41,9 +41,9 @@ class TestScheduler(Tester):
             ETC = desisurvey.etc.ExposureTimeCalculator()
             for mjd in np.arange(dusk, dawn, 15. / (24. * 60.)):
                 # TILEID,PASSNUM,SNR2FRAC,EXPFAC,AIRMASS,PROGRAM,PROGEND
-                next = scheduler.next_tile(mjd, ETC, seeing=1.1, transp=0.95)
+                next = scheduler.next_tile(mjd, ETC, seeing=1.1, transp=0.95, skylevel=1)
                 # Check that the restored scheduler gives the same results.
-                next2 = scheduler2.next_tile(mjd, ETC, seeing=1.1, transp=0.95)
+                next2 = scheduler2.next_tile(mjd, ETC, seeing=1.1, transp=0.95, skylevel=1)
                 for field, field2 in zip(next, next2):
                     self.assertEqual(field, field2)
                 tileid = next[0]                

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -133,13 +133,17 @@ class Tiles(object):
         cosZ = self.tile_coef_A[mask] + self.tile_coef_B[mask] * np.cos(hour_angle)
         return desisurvey.utils.cos_zenith_to_airmass(cosZ)
 
-    def index(self, tileID):
+    def index(self, tileID, return_mask=False):
         """Map tile ID to array index.
 
         Parameters
         ----------
         tileID : int or array
             Tile ID value(s) to convert.
+        mask : bool
+            if mask=True, an additional mask array is returned, indicating which
+            IDs were present in the tile array.  Otherwise, an exception is 
+            raised if tiles were not found.
 
         Returns
         -------
@@ -150,9 +154,15 @@ class Tiles(object):
         tileID = np.atleast_1d(tileID)
         idx = np.searchsorted(self.tileID, tileID)
         bad = self.tileID[idx] != tileID
-        if np.any(bad):
+        if not return_mask and np.any(bad):
             raise ValueError('Invalid tile ID(s): {}.'.format(tileID[bad]))
-        return idx[0] if scalar else idx
+        mask = ~bad
+        idx = idx[0] if scalar else idx
+        mask = mask[0] if scalar else mask
+        res = idx
+        if return_mask:
+            res = (res, mask)
+        return res
 
     @property
     def tile_over(self):

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -142,7 +142,7 @@ class Tiles(object):
             Tile ID value(s) to convert.
         mask : bool
             if mask=True, an additional mask array is returned, indicating which
-            IDs were present in the tile array.  Otherwise, an exception is 
+            IDs were present in the tile array.  Otherwise, an exception is
             raised if tiles were not found.
 
         Returns


### PR DESCRIPTION
Adds Next Tile Selector functionality to the desisurvey scheduler.

The key addition of this routine to desisurvey is the NTS.py module that connects to the DOS NFS.py module to give the online system access to the desisurvey scheduler.

A few minor changes were made outside NTS.py:
- Planner and Scheduler save(...) methods were made atomic
- scheduler.next_tile(...) now accepts an program argument.  Tiles are selected from this program.
- next_tile also takes a skylevel argument, which is presently ignored.
- tiles.index(...) now accepts a default False return_mask argument.  If True, instead of raising an exception if an invalid tile ID is sent, the function returns a mask, indicating which IDs were valid.