### PR TITLE
IERS workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=2.0.4
-        - SPHINX_VERSION=1.5
-        - DESIUTIL_VERSION=1.9.9
-        - SPECLITE_VERSION=0.7
-        - SPECSIM_VERSION=v0.9
+        - ASTROPY_VERSION=2.0.14
+        - SPHINX_VERSION=1.8.5
+        - DESIUTIL_VERSION=2.0.1
+        - SPECLITE_VERSION=0.8
+        - SPECSIM_VERSION=v0.13
         # - SPECTER_VERSION=0.6.0
-        - DESIMODEL_VERSION=0.9.8
-        - DESIMODEL_DATA=branches/test-0.9.8
+        - DESIMODEL_VERSION=0.10.3
+        - DESIMODEL_DATA=branches/test-0.10
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - MAIN_CMD='python setup.py'
@@ -76,8 +76,10 @@ env:
         # Debug the Travis install process.
         - DEBUG=False
     matrix:
-        # - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.5 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='bdist_egg'
 
 matrix:
     # Don't wait for allowed failures.
@@ -92,53 +94,15 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx --warning-is-error'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx --warning-is-error'
         #         CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
         #         PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
-        # Do a bdist_egg compile.  This will catch things like syntax errors
-        # without needing to do a full python setup.py test
-        - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='bdist_egg'
-
         # Default versions
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --coverage'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
-
-        # Default versions
-       # - os: linux
-       #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-       #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-       #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
-
-        # More recent versions
-        # We're already on the "more recent" versions.
-        # - os: linux
-        #   env: PYTHON_VERSION=2.7 ASTROPY_VERSION=1.1.1 NUMPY_VERSION=1.10.4 SCIPY_VERSION=0.17.0 SETUP_CMD='test'
-
-        # - os: osx
-        #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-        # - python: 3.3
-        #   env: SETUP_CMD='test --open-files'
-        # - python: 3.4
-        #   env: SETUP_CMD='test --open-files'
-
-        # Now try do scipy on 2.7 and an appropriate 3.x build (with latest numpy)
-        # We also note the code coverage on Python 2.7.
-        # - python: 2.7
-        #   env: SETUP_CMD='test --coverage'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
-        # - python: 3.4
-        #   env: SETUP_CMD='test'  OPTIONAL_DEPS=true LC_CTYPE=C.ascii LC_ALL=C.ascii
-
-        # Try older numpy versions
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
         # Do a PEP8 test
         # - python: 2.7

--- a/bin/update_iers_frozen
+++ b/bin/update_iers_frozen
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Update the iers_frozen file.
+"""
+from pkg_resources import resource_filename
+from desisurvey.utils import update_iers
+
+frozen = resource_filename('desisurvey', 'data/iers_frozen.ecsv')
+print("Updating {0}".format(frozen))
+update_iers(frozen)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,17 @@
 desisurvey change log
 =====================
 
-0.12.1 (unreleased)
+0.12.2 (unreleased)
 -------------------
 
 * No changes yet (but likely to include more AP/NTS/ICS integration)
+
+0.12.1 (2019-12-20)
+-------------------
+
+* Workaround for missing IERS server (PR `#100`_).
+
+.. _`#100`: https://github.com/desihub/desisurvey/pull/100
 
 0.12.0 (2019-08-09)
 -------------------

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -165,7 +165,9 @@ def update_iers(save_name='iers_frozen.ecsv', num_avg=1000):
         raise ValueError('Expected .ecsv extension for {0}.'.format(save_name))
 
     # Download the latest IERS_A table
-    iers = astropy.utils.iers.IERS_A.open(astropy.utils.iers.IERS_A_URL)
+    if astropy.utils.iers.conf.iers_auto_url == 'frozen':
+        raise ValueError("Attempting to update a frozen IERS A table!")
+    iers = astropy.utils.iers.IERS_A.open(astropy.utils.iers.conf.iers_auto_url)
     last = astropy.time.Time(iers['MJD'][-1], format='mjd').datetime
     log.info('Updating to current IERS-A table with coverage up to {0}.'
              .format(last.date()))

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -29,6 +29,9 @@ _telescope_location = None
 _iers_is_frozen = False
 _dome_closed_fractions = None
 
+# Workaround for offline primary IERS server.
+astropy.utils.iers.Conf.iers_auto_url.set('ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all')
+
 
 def freeze_iers(name='iers_frozen.ecsv', ignore_warnings=True):
     """Use a frozen IERS table saved with this package.


### PR DESCRIPTION
This PR adds a workaround URL that `update_iers()`.  However, we also realized while testing this that `update_iers()` is intended to be run once at the start of the survey and then **NEVER AGAIN**.  For all other things that need IERS-A, `freeze_iers()` should be called first.

This means that any errors resulting from attempts to download IERS-A in other packages are caused by those packages failing to properly call `freeze_iers()`, *not* from an error in `desisurvey`.

In addition, the Travis test matrix has been updated, and a command-line script to call `update_iers()` is added.

The existing iers_frozen.ecsv file is a few years old, but let's not update that until we make a collective, documented decision.