### PR TITLE
Enable using NTS/desisurvey with CMX tile file; add HA limit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib pyephem"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib pyephem pytz"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -87,11 +87,7 @@ class NTS():
             self.night = night
 
         config = desisurvey.config.Configuration()
-        commissioning = getattr(config, 'commissioning', False)
-        if commissioning:
-            self.rules = None
-        else:
-            self.rules = desisurvey.rules.Rules()
+        self.rules = desisurvey.rules.Rules()
         # should look for rules file in obsplan dir?
         try:
             nightstr = self.night.isoformat()
@@ -228,12 +224,8 @@ def afternoon_plan(night=None, lastnight=None):
         night = datetime.date.today().isoformat()
 
     config = desisurvey.config.Configuration()
-    commissioning = getattr(config, 'commissioning', False)
-    if commissioning:
-        rules = None
-    else:
-        rules = desisurvey.rules.Rules()
     # should look for rules file in obsplan dir?
+    rules = desisurvey.rules.Rules()
     if lastnight is not None:
         planner = desisurvey.plan.Planner(
             rules, restore='planner_end_{}.fits' % lastnight)

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -223,9 +223,8 @@ def afternoon_plan(night=None, lastnight=None):
     if night is None:
         night = datetime.date.today().isoformat()
 
-    config = desisurvey.config.Configuration()
-    # should look for rules file in obsplan dir?
     rules = desisurvey.rules.Rules()
+    # should look for rules file in obsplan dir?
     if lastnight is not None:
         planner = desisurvey.plan.Planner(
             rules, restore='planner_end_{}.fits' % lastnight)

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -85,7 +85,6 @@ class NTS():
                   self.night)
         else:
             self.night = night
-
         self.rules = desisurvey.rules.Rules()
         # should look for rules file in obsplan dir?
         try:
@@ -221,7 +220,6 @@ def afternoon_plan(night=None, lastnight=None):
     """
     if night is None:
         night = datetime.date.today().isoformat()
-
     rules = desisurvey.rules.Rules()
     # should look for rules file in obsplan dir?
     if lastnight is not None:

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -48,6 +48,7 @@ import desisurvey.rules
 import desisurvey.plan
 import desisurvey.scheduler
 import desisurvey.etc
+import desisurvey.utils
 import datetime
 
 
@@ -84,7 +85,13 @@ class NTS():
                   self.night)
         else:
             self.night = night
-        self.rules = desisurvey.rules.Rules()
+
+        config = desisurvey.config.Configuration()
+        commissioning = getattr(config, 'commissioning', False)
+        if commissioning:
+            self.rules = None
+        else:
+            self.rules = desisurvey.rules.Rules()
         # should look for rules file in obsplan dir?
         try:
             nightstr = self.night.isoformat()
@@ -219,7 +226,13 @@ def afternoon_plan(night=None, lastnight=None):
     """
     if night is None:
         night = datetime.date.today().isoformat()
-    rules = desisurvey.rules.Rules()
+
+    config = desisurvey.config.Configuration()
+    commissioning = getattr(config, 'commissioning', False)
+    if commissioning:
+        rules = None
+    else:
+        rules = desisurvey.rules.Rules()
     # should look for rules file in obsplan dir?
     if lastnight is not None:
         planner = desisurvey.plan.Planner(
@@ -232,7 +245,6 @@ def afternoon_plan(night=None, lastnight=None):
     # restore: maybe check directory, and restore if file present?  EFS
     # planner.save(), scheduler.save()
     # planner.restore(), scheduler.restore()
-    import desisurvey.utils
     planner.afternoon_plan(desisurvey.utils.get_date(night),
                            scheduler.completed)
     # currently afternoon planning checks to see what tiles have been marked

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -86,7 +86,6 @@ class NTS():
         else:
             self.night = night
 
-        config = desisurvey.config.Configuration()
         self.rules = desisurvey.rules.Rules()
         # should look for rules file in obsplan dir?
         try:

--- a/py/desisurvey/data/config-cmx.yaml
+++ b/py/desisurvey/data/config-cmx.yaml
@@ -93,6 +93,19 @@ nominal_exposure_time:
     DARK: 1000 s
     GRAY: 1000 s
     BRIGHT: 300 s
+    ALL_BGS: 300 s
+    ALL_BRIGHT_STARS: 300 s
+    ALL_ELG: 300 s
+    ALL_LRG: 300 s
+    ALL_MED_STARS: 300 s
+    ALL_MWS: 300 s
+    ALL_QSO: 300 s
+    BLANK_SKY: 300 s
+    CATASTROPHE_BRIGHTSTARS: 300 s
+    CATASTROPHE_MEDSTARS: 300 s
+    EVEN_ODD: 300 s
+    SKY_WITH_STAR: 300 s
+
 nominal_conditions:
     # Moon below the horizon
     seeing: 1.1 arcsec
@@ -134,11 +147,8 @@ fiber_assignment_cadence: monthly
 # Similarly, a delay of 0 indicates that fibers are assigned on
 # the first day / month after the covering tiles are completed.
 fiber_assignment_order:
-    P1: P0 delay 1
-    P2: P0+P1 delay 1
-    P3: P0+P1 delay 1
-    P6: P5 delay 1
-    P7: P5+P6 delay 1
+    P999: P998 delay 1
+
 
 # Nominal tile radius for determining whether two tiles overlap.
 tile_radius: 1.63 deg
@@ -156,7 +166,11 @@ tile_radius: 1.63 deg
 # - Pass numbers are arbitrary integers and do not need to be consecutive
 #   or dense. However use of non-standard values will generally require
 #   an update to fiber_assignment_order, above.
-tiles_file: desi-tiles.fits
+tiles_file: '{DESISURVEY_OUTPUT}/ALL_CMX_tiles2.fits'
+
+commissioning: True
+# tile file is a commissioning tile file. This disables checks related
+# to PROGRAM, etc.
 
 # Base path to pre-pended to all non-absolute paths used for reading and
 # writing files managed by this package. The pattern {...} will be expanded

--- a/py/desisurvey/data/rules-cmx.yaml
+++ b/py/desisurvey/data/rules-cmx.yaml
@@ -1,0 +1,14 @@
+#-------------------------------------------------------------------
+# Definition of tile groups that are separately scheduled
+# and prioritized. See doc/rules.rst for an explanation for the format.
+#-------------------------------------------------------------------
+
+# Implement a dummy rules file for commissioning.
+
+A:
+    passes: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+    dec_min: -90
+    dec_order: +0.2
+    rules:
+        A(0): { START: 1.0 }
+        # looks to me like this is further assumed for all passes

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -39,11 +39,15 @@ def load_design_hourangle(name='surveyinit.fits'):
     """
     config = desisurvey.config.Configuration()
     fullname = config.get_path(name)
-    with astropy.io.fits.open(fullname, memmap=False) as hdus:
-        HA = hdus['DESIGN'].data['HA'].copy()
     tiles = desisurvey.tiles.get_tiles()
-    if HA.shape != (tiles.ntiles,):
-        raise ValueError('Read unexpected HA shape.')
+    commissioning = getattr(config, 'commissioning', False)
+    if commissioning:
+        HA = np.zeros(len(tiles.tileRA), dtype='f4')
+    else:
+        with astropy.io.fits.open(fullname, memmap=False) as hdus:
+            HA = hdus['DESIGN'].data['HA'].copy()
+        if HA.shape != (tiles.ntiles,):
+            raise ValueError('Read unexpected HA shape.')
     return HA
 
 


### PR DESCRIPTION
This PR lets NTS/desisurvey work with a commissioning tile file.  This requires some hacks around the default PROGRAMS; setting commissioning: True in the config.yaml file enables this behavior.  Commissioning tile files also don't get optimized HA assignments; commissioning tiles aim for HA = 0.

Extraneously, it also includes a maximum hour angle limit and a tweak to next_tile to allow it to go backwards in night_index (for instance, if someone requests a particular MJD that is earlier than a formerly requested MJD).  