### PR TITLE
Migrate to single status file; rudimentary afternoon planning; allow tile & status files to not match.

### DIFF
--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -50,12 +50,7 @@ import desisurvey.scheduler
 import desisurvey.etc
 import desisurvey.utils
 import desisurvey.config
-import datetime
 from astropy.io import ascii
-
-
-def night_to_str(night):
-    return night.isoformat().replace('-', '')
 
 
 class QueuedList():
@@ -114,7 +109,7 @@ class NTS():
         self.rules = desisurvey.rules.Rules()
         # should look for rules file in obsplan dir?
         try:
-            nightstr = night_to_str(self.night)
+            nightstr = desisurvey.utils.night_to_str(self.night)
             self.planner = desisurvey.plan.Planner(
                 self.rules,
                 restore='desi-status_{}.fits'.format(nightstr))
@@ -253,9 +248,9 @@ def afternoon_plan(night=None, lastnight=None):
     # should look for rules file in obsplan dir?
     if lastnight is not None:
         planner = desisurvey.plan.Planner(
-            rules, restore='desi-status_{}.fits' % lastnight)
+            rules, restore='desi-status_{}.fits'.format(lastnight))
         scheduler = desisurvey.scheduler.Scheduler(
-            restore='desi-status_{}.fits')
+            restore='desi-status_{}.fits'.format(lastnight))
     else:
         planner = desisurvey.plan.Planner(rules)
         scheduler = desisurvey.scheduler.Scheduler()
@@ -272,7 +267,8 @@ def afternoon_plan(night=None, lastnight=None):
     # really the behavior we'd want on the mountain, I'm leaving it until
     # we have something much different.
     # planner.set_donefrac(donefrac, lastexpid)
-    planner.save('desi-status_{}.fits'.format(night_to_str(night)))
+    planner.save('desi-status_{}.fits'.format(
+        desisurvey.utils.night_to_str(night)))
 
 
 if __name__ == "__main__":
@@ -287,5 +283,5 @@ if __name__ == "__main__":
                         help='night to restore, default: start fresh.',
                         default=None)
 
-    parser.parse_args()
-    afternoon_plan(parser.night, parser.lastnight)
+    args = parser.parse_args()
+    afternoon_plan(args.night, args.lastnight)

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -86,7 +86,7 @@ def azinrange(az, low, high):
 
     We transform high so that it is in the range [low, low+360].  We then
     transform az likewise, so that the test can be done as low <= az <= high.
-    In this scheme, azinrange(0, 2, 1) = True, since low, high = [2, 1] is 
+    In this scheme, azinrange(0, 2, 1) = True, since low, high = [2, 1] is
     interpreted as all angles between 2 and 361 degrees.
 
     Parameters

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -149,7 +149,7 @@ class NTS():
                                       nightstr, obsplan)
             if not os.path.exists(obsplannew):
                 self.log.error('Could not find obsplan configuration '
-                               f'{obsplan}!')
+                               '{}!'.format(obsplan))
                 raise ValueError('Could not find obsplan configuration!')
             else:
                 obsplan = obsplannew
@@ -276,7 +276,7 @@ class NTS():
         if program is None:
             maxtime = min([maxtime, mjd_program_end-maxtime])
 
-        tileidstr = f'{tileid:06d}'
+        tileidstr = '{:06d}'.format(tileid)
         fiber_assign = os.path.join(self.config.fiber_assign_dir(),
                                     tileidstr[:3],
                                     'fiberassign-%s.fits' % tileidstr)

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -55,6 +55,13 @@ from astropy import coordinates
 from astropy import units as u
 
 class QueuedList():
+    """Simple class to manage list of exposures already observed in a night.
+    
+    Parameters
+    ----------
+    fn : str
+        file name where QueuedList is backed to disk.
+    """
     def __init__(self, fn):
         self.fn = fn
         self.restore()

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -154,16 +154,17 @@ class NTS():
                           'using current date: {}.'.format(self.night))
         else:
             self.night = night
-        self.rules = desisurvey.rules.Rules(file_name=config.rules())
+        self.rules = desisurvey.rules.Rules(
+            config.get_path(config.rules_file()))
         try:
             nightstr = desisurvey.utils.night_to_str(self.night)
             self.planner = desisurvey.plan.Planner(
                 self.rules,
-                restore='desi-status-{}.fits'.format(nightstr))
+                restore='{}/desi-status-{}.fits'.format(nightstr, nightstr))
             self.scheduler = desisurvey.scheduler.Scheduler(
-                restore='desi-status-{}.fits'.format(nightstr))
+                restore='{}/desi-status-{}.fits'.format(nightstr, nightstr))
             self.queuedlist = QueuedList(
-                config.get_path('queued-{}.dat'.format(nightstr)))
+                config.get_path('{}/queued-{}.dat'.format(nightstr, nightstr)))
         except:
             raise ValueError('Error restoring scheduler & planner files; '
                              'has afternoon planning been performed?')

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -107,13 +107,12 @@ def azinrange(az, low, high):
 
 
 class NTS():
-    def __init__(self, obsplan='config.yaml', fiber_assign_dir, defaults={}, night=None):
+    def __init__(self, obsplan='config.yaml', fiber_assign_dir='', defaults={}, night=None):
         """Initialize a new instance of the Next Tile Selector.
 
         Parameters
         ----------
-        obsplan : not currently used; planner initialized from default
-            scheduler directory.
+        obsplan : config.yaml to load
 
         fiber_assign_dir : directory where fiber assign files are located
 

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -73,7 +73,7 @@ class QueuedList():
         # could work harder to make this atomic.
 
 
-def azinzrange(az, low, high):
+def azinrange(az, low, high):
     """Return whether azimuth is between low and high, trying to respect the
     360 deg boundary.
 

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -100,7 +100,7 @@ def azinrange(az, low, high):
 
 
 class NTS():
-    def __init__(self, obsplan, fiber_assign_dir, defaults={}, night=None):
+    def __init__(self, obsplan='config.yaml', fiber_assign_dir, defaults={}, night=None):
         """Initialize a new instance of the Next Tile Selector.
 
         Parameters
@@ -122,7 +122,11 @@ class NTS():
         """
         self.obsplan = obsplan
         self.fiber_assign_dir = fiber_assign_dir
+        # making a new NTS; clear out old configuration / tile information
+        desisurvey.config.Configuration.reset()
+        _ = desisurvey.tiles.get_tiles(use_cache=False, write_cache=True)
         config = desisurvey.config.Configuration()
+
         self.default_seeing = defaults.get('seeing', 1.0)
         self.default_transparency = defaults.get('transparency', 0.9)
         self.default_skylevel = defaults.get('skylevel', 1000.0)
@@ -133,8 +137,7 @@ class NTS():
                   self.night)
         else:
             self.night = night
-        self.rules = desisurvey.rules.Rules()
-        # should look for rules file in obsplan dir?
+        self.rules = desisurvey.rules.Rules(file_name=config.rules)
         try:
             nightstr = desisurvey.utils.night_to_str(self.night)
             self.planner = desisurvey.plan.Planner(

--- a/py/desisurvey/config.py
+++ b/py/desisurvey/config.py
@@ -137,6 +137,17 @@ class Configuration(Node):
         Configuration.__instance = None
 
 
+    @staticmethod
+    def _get_full_path(file_name):
+        # Locate the config file in our pkg data/ directory if no path is given.
+        if os.path.split(file_name)[0] == '':
+            full_path = astropy.utils.data._find_pkg_data_path(
+                os.path.join('data', file_name))
+        else:
+            full_path = file_name
+        return full_path
+
+
     def __new__(cls, file_name=None):
         """Implement a singleton access pattern.
         """
@@ -175,12 +186,7 @@ class Configuration(Node):
         # Remember the file name since it is not allowed to change.
         self.file_name = file_name
 
-        # Locate the config file in our pkg data/ directory if no path is given.
-        if os.path.split(file_name)[0] == '':
-            full_path = astropy.utils.data._find_pkg_data_path(
-                os.path.join('data', file_name))
-        else:
-            full_path = file_name
+        full_path = self._get_full_path(file_name)
 
         # Validate that all mapping keys are valid python identifiers
         # and that there are no embedded sequences.

--- a/py/desisurvey/data/config-cmx.yaml
+++ b/py/desisurvey/data/config-cmx.yaml
@@ -167,7 +167,7 @@ tile_radius: 1.63 deg
 # - Pass numbers are arbitrary integers and do not need to be consecutive
 #   or dense. However use of non-standard values will generally require
 #   an update to fiber_assignment_order, above.
-tiles_file: CMX_58_DITHERED_TILES_Jan2020_s.fits
+tiles_file: SV0_612tiles_March2020_uniquepassprogram.fits
 
 commissioning: True
 # tile file is a commissioning tile file. This disables checks related

--- a/py/desisurvey/data/config-cmx.yaml
+++ b/py/desisurvey/data/config-cmx.yaml
@@ -105,6 +105,7 @@ nominal_exposure_time:
     CATASTROPHE_MEDSTARS: 300 s
     EVEN_ODD: 300 s
     SKY_WITH_STAR: 300 s
+    CMX_DITHERING: 30 s
 
 nominal_conditions:
     # Moon below the horizon
@@ -166,7 +167,7 @@ tile_radius: 1.63 deg
 # - Pass numbers are arbitrary integers and do not need to be consecutive
 #   or dense. However use of non-standard values will generally require
 #   an update to fiber_assignment_order, above.
-tiles_file: '{DESISURVEY_OUTPUT}/ALL_CMX_tiles2.fits'
+tiles_file: CMX_58_DITHERED_TILES_Jan2020_s.fits
 
 commissioning: True
 # tile file is a commissioning tile file. This disables checks related
@@ -176,3 +177,9 @@ commissioning: True
 # writing files managed by this package. The pattern {...} will be expanded
 # using environment variables.
 output_path: '{DESISURVEY_OUTPUT}'
+
+rules_file: rules-cmx.yaml
+
+fiber_assign_dir: /global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/
+
+spectra_dir: /global/cfs/cdirs/desi/spectro/data

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -160,3 +160,5 @@ tiles_file: desi-tiles.fits
 # writing files managed by this package. The pattern {...} will be expanded
 # using environment variables.
 output_path: '{DESISURVEY_OUTPUT}'
+
+rules: rules.yaml

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -161,4 +161,4 @@ tiles_file: desi-tiles.fits
 # using environment variables.
 output_path: '{DESISURVEY_OUTPUT}'
 
-rules: rules.yaml
+rules_file: rules.yaml

--- a/py/desisurvey/data/rules-cmx.yaml
+++ b/py/desisurvey/data/rules-cmx.yaml
@@ -6,9 +6,28 @@
 # Implement a dummy rules file for commissioning.
 
 A:
-    passes: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+    passes: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20
     dec_min: -90
     dec_order: +0.2
     rules:
         A(0): { START: 1.0 }
-        # looks to me like this is further assumed for all passes
+        A(1): { START: 1.0 }
+        A(2): { START: 1.0 }
+        A(3): { START: 1.0 }
+        A(4): { START: 1.0 }
+        A(5): { START: 1.0 }
+        A(6): { START: 1.0 }
+        A(7): { START: 1.0 }
+        A(8): { START: 1.0 }
+        A(9): { START: 1.0 }
+        A(10): { START: 1.0 }
+        A(11): { START: 1.0 }
+        A(12): { START: 1.0 }
+        A(13): { START: 1.0 }
+        A(14): { START: 1.0 }
+        A(15): { START: 1.0 }
+        A(16): { START: 1.0 }
+        A(17): { START: 1.0 }
+        A(18): { START: 1.0 }
+        A(19): { START: 1.0 }
+        A(20): { START: 1.0 }

--- a/py/desisurvey/data/rules-layers.yaml
+++ b/py/desisurvey/data/rules-layers.yaml
@@ -8,18 +8,18 @@
 
 DARK:
     dec_order: +0.2
-    passes: 0,1,2,3
+    passes: 1,2,3,4
     rules:
-        DARK(0): { START: 1.0 }
-        DARK(1): { DARK(0): 1.0 }
+        DARK(1): { START: 1.0 }
         DARK(2): { DARK(1): 1.0 }
         DARK(3): { DARK(2): 1.0 }
+        DARK(4): { DARK(3): 1.0 }
 
 GRAY:
     dec_order: +0.2
-    passes: 4
+    passes: 0
     rules:
-        GRAY(4): { START: 1.0 }
+        GRAY(0): { START: 1.0 }
 
 BRIGHT:
     dec_order: +0.2

--- a/py/desisurvey/data/rules.yaml
+++ b/py/desisurvey/data/rules.yaml
@@ -3,36 +3,36 @@
 # and prioritized. See doc/rules.rst for an explanation for the format.
 #-------------------------------------------------------------------
 
-# 15 < DEC < 25 stripe in NGC. Our goal is to observe this strip in DARK-0,1
-# GRAY-4 and BRIGHT-5,6 in year-1, then observe DARK-2,3 and BRIGHT-7 in year-2,
+# 15 < DEC < 25 stripe in NGC. Our goal is to observe this strip in DARK-1,2
+# GRAY-0 and BRIGHT-5,6 in year-1, then observe DARK-3,4 and BRIGHT-7 in year-2,
 # resulting in full depth for all programs by the end of year-2.
 N10:
     cap: N
     dec_min: 15
     dec_max: 25
     dec_order: +0.2
-    passes: 2,3,4,7
+    passes: 0,3,4,7
     rules:
-        N10(2): { N10LO(0): 0.8, N10HI(0): 1.0 }
-        N10(3): { N10LO(0): 0.6, N10HI(0): 0.8, N10(2): 1.0 }
-        N10(4): { START: 1.0 }
+        N10(0): { START: 1.0 }
+        N10(3): { N10LO(1): 0.8, N10HI(1): 1.0 }
+        N10(4): { N10LO(1): 0.6, N10HI(1): 0.8, N10(3): 1.0 }
         N10(7): { N10LO(5): 0.8, N10HI(5): 1.0 }
 
-# Pass-1 tiles in N10 need to cover passes 2, 3 for fiber assignment.
+# Pass-2 tiles in N10 need to cover passes 3, 4 for fiber assignment.
+N10P2:
+    covers: N10(3)+N10(4)
+    dec_order: +0.2
+    passes: 2
+    rules:
+        N10P2(2): { START: 0.8, N10P1(1): 1.0 }
+
+# Pass-1 tiles in N10 need to cover passes 2, 3, 4 for fiber assignment.
 N10P1:
-    covers: N10(2)+N10(3)
+    covers: N10P2(2)+N10(3)+N10(4)
     dec_order: +0.2
     passes: 1
     rules:
-        N10P1(1): { START: 0.8, N10P0(0): 1.0 }
-
-# Pass-0 tiles in N10 need to cover passes 1, 2, 3 for fiber assignment.
-N10P0:
-    covers: N10P1(1)+N10(2)+N10(3)
-    dec_order: +0.2
-    passes: 0
-    rules:
-        N10P0(0): { START: 1.0 }
+        N10P1(1): { START: 1.0 }
 
 # Pass-6 tiles in N10 need to cover pass 7 for fiber assignment.
 N10P6:
@@ -59,11 +59,11 @@ N10LO:
     max_orphans: 4
     passes: 0,1,2,3,4,5,6,7
     rules:
-        N10LO(0): { START: 0.7, N10P1(1): 1.0 }
-        N10LO(1): { N10HI(0): 0.6, N10(3): 1.0 }
-        N10LO(2): { N10HI(1): 1.0 }
-        N10LO(3): { N10HI(1): 1.0 }
-        N10LO(4): { START: 0.6, N10(4): 1.0 }
+        N10LO(0): { START: 0.6, N10(0): 1.0 }
+        N10LO(1): { START: 0.7, N10P2(2): 1.0 }
+        N10LO(2): { N10HI(1): 0.6, N10(4): 1.0 }
+        N10LO(3): { N10HI(2): 1.0 }
+        N10LO(4): { N10HI(2): 1.0 }
         N10LO(5): { START: 0.6, N10P6(6): 1.0 }
         N10LO(6): { N10HI(5): 0.6, N10(7): 1.0 }
         N10LO(7): { N10HI(6): 1.0 }
@@ -76,11 +76,11 @@ N10HI:
     dec_order: +0.2
     passes: 0,1,2,3,4,5,6,7
     rules:
-        N10HI(0): { START: 0.3, N10LO(0): 0.6, N10P1(1): 1.0 }
-        N10HI(1): { N10HI(0): 0.4, N10(3): 0.8, N10LO(1): 1.0 }
-        N10HI(2): { N10HI(1): 0.8, N10LO(2): 1.0 }
-        N10HI(3): { N10HI(1): 0.8, N10LO(3): 1.0 }
-        N10HI(4): { START: 0.4, N10(4): 0.8, N10LO(4): 1.0 }
+        N10HI(0): { START: 0.4, N10(0): 0.8, N10LO(0): 1.0 }
+        N10HI(1): { START: 0.3, N10LO(1): 0.6, N10P2(2): 1.0 }
+        N10HI(2): { N10HI(1): 0.4, N10(4): 0.8, N10LO(2): 1.0 }
+        N10HI(3): { N10HI(2): 0.8, N10LO(3): 1.0 }
+        N10HI(4): { N10HI(2): 0.8, N10LO(4): 1.0 }
         N10HI(5): { START: 0.4, N10P6(6): 0.8, N10LO(4): 1.0 }
         N10HI(6): { N10(7): 0.8, N10LO(6): 1.0 }
         N10HI(7): { N10HI(6): 0.8, N10LO(7): 1.0 }
@@ -94,10 +94,10 @@ SLO:
     passes: 0,1,2,3,4,5,6,7
     rules:
         SLO(0): { START: 1.0 }
-        SLO(1): { START: 0.5, SLO(0): 1.0 }
-        SLO(2): { SLO(0): 0.5, SLO(1): 1.0 }
+        SLO(1): { START: 1.0 }
+        SLO(2): { START: 0.5, SLO(1): 1.0 }
         SLO(3): { SLO(1): 0.5, SLO(2): 1.0 }
-        SLO(4): { START: 1.0 }
+        SLO(4): { SLO(2): 0.5, SLO(3): 1.0 }
         SLO(5): { START: 1.0 }
         SLO(6): { START: 0.5, SLO(5): 1.0 }
         SLO(7): { SLO(5): 0.5, SLO(6): 1.0 }
@@ -111,10 +111,10 @@ SHI:
     passes: 0,1,2,3,4,5,6,7
     rules:
         SHI(0): { START: 0.5, SLO(0): 1.0 }
-        SHI(1): { SLO(0): 0.5, SLO(1): 1.0 }
+        SHI(1): { START: 0.5, SLO(1): 1.0 }
         SHI(2): { SLO(1): 0.5, SLO(2): 1.0 }
         SHI(3): { SLO(2): 0.5, SLO(3): 1.0 }
-        SHI(4): { START: 0.5, SLO(4): 1.0 }
+        SHI(4): { SLO(3): 0.5, SLO(4): 1.0 }
         SHI(5): { START: 0.5, SLO(5): 1.0 }
         SHI(6): { SLO(5): 0.5, SLO(6): 1.0 }
         SHI(7): { SLO(6): 0.5, SLO(7): 1.0 }

--- a/py/desisurvey/etc.py
+++ b/py/desisurvey/etc.py
@@ -305,8 +305,9 @@ class ExposureTimeCalculator(object):
         for program in desisurvey.tiles.Tiles.PROGRAMS:
             nomtime = getattr(config.nominal_exposure_time, program, None)
             if nomtime is None:
-                self.log.warning(f'Unrecognized program {program}, using default '
-                                 'exposure time of 1000 s')
+                self.log.warning(
+                    'Unrecognized program {}, '.format(program) +
+                    'using default exposure time of 1000 s')
                 nomtime = 1000/24/60/60
             else:
                 nomtime = nomtime().to(u.day).value

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -311,6 +311,8 @@ class Planner(object):
         self.tile_available = available.copy()
         self.log.info('Fiber assignment files found for {} tiles.'.format(
             np.count_nonzero(available)))
+        if np.count_nonzero(available) == 0:
+            self.log.error('No fiberassign files available for scheduling!')
         if np.any(~mask):
             self.log.warning(
                 'Ignoring {} tiles that were assigned, '.format(sum(~mask)) +

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -184,7 +184,10 @@ class Planner(object):
             raise ValueError('donefrac length must equal lastexpid length.')
         tileind, mask = self.tiles.index(tileid, return_mask=True)
         if np.any(~mask):
-            raise ValueError('some tiles with unknown IDs')
+            self.log.warning('Some tiles with unknown IDs; ignoring')
+            tileind = tileind[mask]
+            donefrac = donefrac[mask]
+            lastexpid = lastexpid[mask]
         self.donefrac[tileind] = donefrac
         self.lastexpid[tileind] = lastexpid
 
@@ -263,8 +266,7 @@ class Planner(object):
     def fiberassign(self, dirname):
         import glob
         import re
-        files = list(glob.iglob(os.path.join(dirname, '**/*.fits'),
-                                recursive=True))
+        files = glob.glob(os.path.join(dirname, '**/*.fits'), recursive=True)
         rgx = re.compile('.*tile-(\d+)\.fits')
         available_tileids = []
         for fn in files:

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -194,6 +194,20 @@ class Planner(object):
             raise RuntimeError('All tile priorities are all <= 0.')
 
     def set_donefrac(self, tileid, donefrac, lastexpid):
+        """Update planner with new tile donefrac and lastexpid.
+
+        Parameters
+        ----------
+        tileid : array
+            1D array of integer tileIDs to update
+
+        donefrac : array
+            1D array of completion fractions for tiles, matching tileid
+
+        lastexpid : array
+            1D array of last expid, giving last exposure ID on each tile
+            must match tileid
+        """
         if len(donefrac) != len(lastexpid):
             raise ValueError('donefrac length must equal lastexpid length.')
         tileind, mask = self.tiles.index(tileid, return_mask=True)
@@ -285,6 +299,20 @@ class Planner(object):
                       .format(np.count_nonzero(run_now), np.count_nonzero(delayed), night))
 
     def fiberassign(self, dirname):
+        """Update list of tiles available for spectroscopy.
+
+        Scans given directory looking for fiberassign file and populates Plan
+        object accordingly.
+
+        Parameters
+        ----------
+        dirname : str
+            file name of directory where fiberassign files are to be found
+            This directory is recursively scanned for all files with names
+            matching tile-(\d+)\.fits.  TILEIDs are populated according to
+            the name of the fiberassign file, and any header information is 
+            ignored.
+        """
         import glob
         import re
         files = glob.glob(os.path.join(dirname, '**/*.fits'), recursive=True)
@@ -306,6 +334,17 @@ class Planner(object):
                 'but not found in the tile file.')
 
     def afternoon_plan(self, night, fiber_assign_dir=None):
+        """Update plan for a given night.  Update tile availability and priority.
+
+        Parameters
+        ----------
+        night : str
+            night string, YYYY-MM-DD, to be planned.
+            This argument has no effect for when Plan.simulate = False; in this
+            case, tile availability and priority is based entirely on what
+            files are currently present in the fiberassign directory and what
+            the planner believes the current tile completions are.
+        """
         config = desisurvey.config.Configuration()
         completed = self.donefrac > config.min_snr2_fraction()
         self.log.debug('Starting afternoon planning for {} with {} / {} tiles completed.'

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -299,7 +299,7 @@ class Planner(object):
         import glob
         import re
         files = glob.glob(os.path.join(dirname, '**/*.fits'), recursive=True)
-        rgx = re.compile('.*tile_(\d+)\.fits')
+        rgx = re.compile('.*fiberassign-(\d+)\.fits')
         available_tileids = []
         for fn in files:
             match = rgx.match(fn)

--- a/py/desisurvey/rules.py
+++ b/py/desisurvey/rules.py
@@ -226,10 +226,11 @@ class Rules(object):
         """
         # First pass through groups to check trigger conditions.
         triggered = {'START': True}
+        config = desisurvey.config.Configuration()
         for i, name in enumerate(self.group_names):
             gid = i+1
             group_sel = self.group_ids == gid
-            if not np.any(group_sel):
+            if not np.any(group_sel) and not config.commissioning:
                 self.log.error('No tiles covered by rule {}'.format(name))
             ngroup = np.count_nonzero(group_sel)
             ndone = np.count_nonzero(completed[group_sel])

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -344,8 +344,6 @@ class Scheduler(object):
             # No tiles left to observe after airmass cut.
             return None, None, None, None, None, program, mjd_program_end
         # Is the moon up?
-        import pdb
-        pdb.set_trace()
         if mjd_now > self.night_ephem['moonrise'] and mjd_now < self.night_ephem['moonset']:
             moon_is_up = True
             # Calculate the moon (RA,DEC).

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -79,10 +79,12 @@ class Scheduler(object):
             if not os.path.exists(fullname):
                 raise RuntimeError('Cannot restore scheduler from non-existent "{}".'.format(fullname))
             t = astropy.table.Table.read(fullname, hdu='STATUS')
-            self.snr2frac = t['DONEFRAC'].copy()
-            self.lastexpid = t['LASTEXPID'].copy()
-            if self.snr2frac.shape != (ntiles,):
-                raise ValueError('Invalid snr2frac array shape.')
+            ind, mask = self.tiles.index(t['TILEID'], return_mask=True)
+            ind = ind[mask]
+            self.snr2frac = np.zeros(ntiles, 'f4')
+            self.lastexpid = np.zeros(ntiles, 'i4')
+            self.snr2frac[ind] = t['DONEFRAC'][mask].copy()
+            self.lastexpid[ind] = t['LASTEXPID'][mask].copy()
             self.log.debug('Restored scheduler snapshot from "{}".'.format(fullname))
         else:
             # Initialize for a new survey.

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -315,15 +315,17 @@ class Scheduler(object):
         while ((self.night_index + 1 < len(self.night_changes)) and
                (mjd_now >= self.night_changes[self.night_index + 1])):
             self.night_index += 1
+        self.tile_sel = np.ones(self.tiles.ntiles, dtype=bool)
         if program is None:
             program = self.night_programs[self.night_index]
             # How much time remaining in this program?
             mjd_program_end = self.night_changes[self.night_index + 1]
+            self.tile_sel &= self.tiles.allowed_in_conditions[program]
         else:
+            self.tile_sel &= self.tiles.program_mask[program]
             mjd_program_end = self.night_changes[-1]  # end of night?
-        t_remaining = mjd_program_end - mjd_now
         # Select available tiles in this program.
-        self.tile_sel = self.tiles.program_mask[program] & self.in_night_pool
+        self.tile_sel &= self.in_night_pool
         if not np.any(self.tile_sel):
             # No tiles available to observe tonight in this program.
             return None, None, None, None, None, program, mjd_program_end

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -78,7 +78,7 @@ class Scheduler(object):
             fullname = config.get_path(restore)
             if not os.path.exists(fullname):
                 raise RuntimeError('Cannot restore scheduler from non-existent "{}".'.format(fullname))
-            t = astropy.table.Table.read(fullname, hdu='PLAN')
+            t = astropy.table.Table.read(fullname, hdu='STATUS')
             self.snr2frac = t['DONEFRAC'].copy()
             self.lastexpid = t['LASTEXPID'].copy()
             if self.snr2frac.shape != (ntiles,):
@@ -410,6 +410,7 @@ class Scheduler(object):
             self.completed[idx] = True
             passidx = self.tiles.pass_index[self.tiles.passnum[idx]]
             self.completed_by_pass[passidx] += 1
+
         # Remember the last tile observed this night.
         self.last_idx = idx
 

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -344,6 +344,8 @@ class Scheduler(object):
             # No tiles left to observe after airmass cut.
             return None, None, None, None, None, program, mjd_program_end
         # Is the moon up?
+        import pdb
+        pdb.set_trace()
         if mjd_now > self.night_ephem['moonrise'] and mjd_now < self.night_ephem['moonset']:
             moon_is_up = True
             # Calculate the moon (RA,DEC).

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -1,15 +1,52 @@
 import desisurvey
 import desisurvey.tiles
-import desisurvey.config
+import desisurvey.rules
+import desisurvey.plan
+import desisurvey.scheduler
+import desiutil.log
 import glob
 import re
 import os
+import shutil
 from desisurvey.scripts import collect_etc
 
-def afternoon_plan(night=None, lastnight=None, fiber_assign_dir=None,
-                   spectra_dir=None, simulate=False):
-    """
-    Perform daily afternoon planning.
+
+"""
+This needs a bit more thought.
+
+"Currently" config is a real path, and it uses DESISURVEY_OUTPUT.
+DESISURVEY_OUTPUT gets prepended to the status file.
+The tiles file is specified in config.yaml as a real path.
+The rules file is specified in config.yaml as a real path (especially
+if I define that to be the case; could instead have it look in config.yaml
+by default; otherwise go to existing rules file).
+
+This all sounds fine; these files could get copied to the AP directory
+for the night and then used.  The config.yaml file would need to be
+updated on copy to point to these copied versions, but that sounds fine, if
+a little annoying.
+
+I want to propose that DESISURVEY_OUTPUT is something like:
+/path/to/desisurvey_output/YYYMMDD/
+NTS gets run pointed to /path/to/desisurvey_output/YYYYMMDD/config.yaml
+where it then sees all the other files it needs (rules, tiles, status file)
+That all sounds okay.
+
+Also need to find a past status file.
+
+Okay, so say DESISURVEY_OUTPUT is a /path/to/desisurvey_output.
+Make NTS and afternoon planning always careful to call config.get_path()
+with a night argument.
+
+Then we can easily find past nights.
+
+
+"""
+
+def afternoon_plan(night=None, restore_etc_stats=None, configfn='config.yaml',
+                   fiber_assign_dir=None, spectra_dir=None, simulate=False,
+                   desisurvey_output=None):
+    """Perform daily afternoon planning.
 
     Afternoon planning identifies tiles available for observation and assigns
     priorities.  It must be performed before the NTS can identify new tiles to
@@ -17,51 +54,124 @@ def afternoon_plan(night=None, lastnight=None, fiber_assign_dir=None,
 
     Params
     ------
-    night : str, ISO 8601.  The night to plan.  Default tonight.
+    night : str
+        Night to plan (YYYMMDD).  Default tonight.
 
-    lastnight : str, ISO 8601.  The previous planned night.  Used for restoring
-        the previous completion status of all tiles.  Defaults to not
-        restoring status, i.e., all previous tile completion information is
-        ignored!
+    restore_etc_stats : str
+        Previous planned night (YYYMMDD) or etc_stats filename.  
+        Used for restoring the previous completion status of all tiles.
+        Defaults to not restoring status, i.e., all previous tile completion
+        information is recomputed from the spectra_dir.
 
-    fiber_assign_dir : str.  Directory where fiber assign files are found.
+    configfn : str
+        File name of desisurvey config to use for plan.
+       
 
-    spectra_dir : str.  Directory where spectra are found.
+    fiber_assign_dir : str
+        Directory where fiber assign files are found.
+
+    spectra_dir : str
+        Directory where spectra are found.
+
+    simulate : bool
+        Use simulated afternoon planning rather than real afternoon planning.
+
+    desisurvey_output : str
+        Afternoon planning config is stored to desisurvey_output/{night}/.
+        Default to DESISURVEY_OUTPUT if None.
     """
+    log = desiutil.log.get_logger()
     if night is None:
         night = desisurvey.utils.get_current_date()
+    nightstr = desisurvey.utils.night_to_str(night)
 
-    night = desisurvey.utils.get_date(night)
+    if desisurvey_output is None:
+        if os.environ.get('DESISURVEY_OUTPUT') is None:
+            log.error('Must set ap_dir or environment variable '
+                      'DESISURVEY_OUTPUT!')
+            return
+        desisurvey_output = os.environ['DESISURVEY_OUTPUT']
+    directory = os.path.join(desisurvey_output, nightstr)
+    if not os.path.exists(directory):
+        os.mkdir(directory)
+
+
+    if configfn is None:
+        configfn = desisurvey.config.Configuration._get_full_path(
+            'config.yaml')
+
+    # figuring out the current date requires having already loaded a
+    # configuration file; we need to get rid of that.
     desisurvey.config.Configuration.reset()
-    config = desisurvey.config.Configuration()
+    config = desisurvey.config.Configuration(configfn)
+    log.info('Loading configuration from {}...'.format(configfn))
+    tilefn = config.get_path(config.tiles_file())
+    rulesfn = config.get_path(config.rules_file())
+    if not os.path.exists(tilefn):
+        log.error('{} does not exist, failing!'.format(tilefn))
+        return
+    if not os.path.exists(rulesfn):
+        log.error('{} does not exist, failing!'.format(rulesfn))
+        return
+    newtilefn = os.path.join(directory, os.path.basename(tilefn))
+    newrulesfn = os.path.join(directory, os.path.basename(rulesfn))
+    newconfigfn = os.path.join(directory, os.path.basename(configfn))
+    if os.path.exists(newtilefn):
+        log.error('{} already exists, failing!'.format(newtilefn))
+        return
+    if os.path.exists(newrulesfn):
+        log.error('{} already exists, failing!'.format(newrulesfn))
+        return
+    shutil.copy(tilefn, newtilefn)
+    shutil.copy(rulesfn, newrulesfn)
+
+    editedtiles = False
+    editedrules = False
+    editedoutputpath = False
+
+    with open(configfn) as fp:
+        lines = fp.readlines()
+        for i in range(len(lines)):
+            if re.match('^output_path:.*', lines[i]):
+                lines[i] = (
+                    'output_path: {}'.format(desisurvey_output) +
+                            '  # edited by afternoon planning\n')
+                editedoutputpath = True
+            elif re.match('^tiles_file:.*', lines[i]):
+                lines[i] = ('tiles_file: {}'.format(newtilefn) +
+                            '  # edited by afternoon planning\n')
+                editedtiles = True
+            elif re.match('^rules_file:.*', lines[i]):
+                lines[i] = ('rules_file: {}'.format(newrulesfn) +
+                            '  # edited by afternoon planning\n')
+                editedrules = True
+    if not (editedtiles and editedrules and editedoutputpath):
+        log.error('Could not find either tiles, rules, or output_path '
+                  'in config file; failing!')
+        return
+    with open(newconfigfn, 'w') as fp:
+        fp.writelines(lines)
+
+    desisurvey.config.Configuration.reset()
+    config = desisurvey.config.Configuration(newconfigfn)
     tilesob = desisurvey.tiles.get_tiles(use_cache=False, write_cache=True)
-    rules = desisurvey.rules.Rules(config.rules())
-    if lastnight is not None:
-        planner = desisurvey.plan.Planner(
-            rules, restore='desi-status-{}.fits'.format(lastnight), simulate=simulate)
-        scheduler = desisurvey.scheduler.Scheduler(
-            restore='desi-status-{}.fits'.format(lastnight))
-    else:
-        planner = desisurvey.plan.Planner(rules, simulate=simulate)
-        scheduler = desisurvey.scheduler.Scheduler()
+    rules = desisurvey.rules.Rules(config.rules_file())
+    planner = desisurvey.plan.Planner(rules, simulate=simulate)
+    scheduler = desisurvey.scheduler.Scheduler()
 
     nightstr = desisurvey.utils.night_to_str(night)
 
-    completed = scheduler.completed
-    if spectra_dir is not None:
-        config = desisurvey.config.Configuration()
-        etcfn = config.get_path('etc-status-{}.fits'.format(nightstr))
-        if os.path.exists(etcfn):
-            from astropy.io import fits
-            print('Using pre-existing ETC status file %s.' % etcfn)
-            tiles = fits.getdata(etcfn, 'TILES')
-        else:
-            tiles, exps = desisurvey.scripts.collect_etc.scan_directory(spectra_dir)
-            collect_etc.write_tile_exp(tiles, exps, etcfn)
-        planner.set_donefrac(tiles['TILEID'], tiles['DONEFRAC'], tiles['LASTEXPID'])
+    if spectra_dir is None:
+        spectra_dir = config.spectra_dir()
+    tiles, exps = collect_etc.scan_directory(spectra_dir,
+                                             start_from=restore_etc_stats)
+    collect_etc.write_tile_exp(tiles, exps, os.path.join(
+        directory, 'etc_stats-{}.fits'.format(night)))
+    planner.set_donefrac(tiles['TILEID'], tiles['DONEFRAC_ETC'],
+                         tiles['LASTEXPID_ETC'])
 
     planner.afternoon_plan(night, fiber_assign_dir=fiber_assign_dir)
-    planner.save('desi-status-{}.fits'.format(nightstr))
+    planner.save('{}/desi-status-{}.fits'.format(nightstr, nightstr))
 
 
 if __name__ == "__main__":
@@ -72,9 +182,17 @@ if __name__ == "__main__":
     parser.add_argument('--night', type=str,
                         help='night to plan, default: tonight',
                         default=None)
-    parser.add_argument('--lastnight', type=str,
-                        help='night to restore, default: start fresh.',
+    parser.add_argument('--restore_etc_stats', type=str,
+                        help='etc_stats file to restore. Default: start fresh.',
                         default=None)
-
+    parser.add_argument('--config', type=str, default=None,
+                        help='config file to use for night')
     args = parser.parse_args()
-    afternoon_plan(args.night, args.lastnight)
+
+    outputdir = os.environ.get('DESISURVEY_OUTPUT', None)
+    log = desiutil.log.get_logger()
+    if outputdir is None:
+        log.error('Environment variable $(DESISURVEY_OUTPUT) must be set.')
+
+    afternoon_plan(night=args.night, restore_etc_stats=args.restore_etc_stats,
+                   configfn=args.config)

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -101,14 +101,14 @@ def afternoon_plan(night=None, restore_etc_stats=None, configfn='config.yaml',
     if configfn is None:
         configfn = desisurvey.config.Configuration._get_full_path(
             'config.yaml')
+    if not os.path.exists(configfn):
+        configfn = desisurvey.config.Configuration._get_full_path(configfn)
 
     # figuring out the current date requires having already loaded a
     # configuration file; we need to get rid of that.
     desisurvey.config.Configuration.reset()
     config = desisurvey.config.Configuration(configfn)
     log.info('Loading configuration from {}...'.format(configfn))
-    if not os.path.exists(configfn):
-        configfn = desisurvey.config.Configuration._get_full_path(configfn)
     tilefn = config.get_path(config.tiles_file())
     rulesfn = config.get_path(config.rules_file())
     if not os.path.exists(tilefn):

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -1,0 +1,87 @@
+import desisurvey
+import desisurvey.tiles
+import desisurvey.config
+import glob
+import re
+import os
+from desisurvey.scripts import collect_etc
+
+def afternoon_plan(night=None, lastnight=None, fiber_assign_dir=None,
+                   spectra_dir=None):
+    """
+    Perform daily afternoon planning.
+
+    Afternoon planning identifies tiles available for observation and assigns
+    priorities.  It must be performed before the NTS can identify new tiles to
+    observe.
+
+    Params
+    ------
+    night : str, ISO 8601.  The night to plan.  Default tonight.
+
+    lastnight : str, ISO 8601.  The previous planned night.  Used for restoring
+        the previous completion status of all tiles.  Defaults to not
+        restoring status, i.e., all previous tile completion information is
+        ignored!
+
+    fiber_assign_dir : str.  Directory where fiber assign files are found.
+
+    spectra_dir : str.  Directory where spectra are found.
+    """
+    if night is None:
+        night = desisurvey.utils.get_current_date()
+
+    night = desisurvey.utils.get_date(night)
+    rules = desisurvey.rules.Rules()
+    # should look for rules file in obsplan dir?
+    if lastnight is not None:
+        planner = desisurvey.plan.Planner(
+            rules, restore='desi-status-{}.fits'.format(lastnight))
+        scheduler = desisurvey.scheduler.Scheduler(
+            restore='desi-status-{}.fits'.format(lastnight))
+    else:
+        planner = desisurvey.plan.Planner(rules)
+        scheduler = desisurvey.scheduler.Scheduler()
+    # restore: maybe check directory, and restore if file present?  EFS
+    # planner.save(), scheduler.save()
+    # planner.restore(), scheduler.restore()
+
+    nightstr = desisurvey.utils.night_to_str(night)
+
+    completed = scheduler.completed
+    if spectra_dir is not None:
+        config = desisurvey.config.Configuration()
+        etcfn = config.get_path('etc-status-{}.fits'.format(nightstr))
+        if os.path.exists(etcfn):
+            from astropy.io import fits
+            print('Using pre-existing ETC status file %s.' % etcfn)
+            tiles = fits.getdata(etcfn, 'TILES')
+        else:
+            tiles, exps = desisurvey.scripts.collect_etc.scan_directory(spectra_dir)
+            collect_etc.write_tile_exp(tiles, exps, etcfn)
+        completed[:] = 0
+        tilesob = desisurvey.tiles.Tiles()
+        idx, mok = tilesob.index(tiles['TILEID'], return_mask=True)
+        completed[idx[mok]] = (
+            tiles['DONEFRAC_ETC'][mok] > config.min_snr2_fraction())
+
+    planner.afternoon_plan(
+        night, completed, fiber_assign_dir=fiber_assign_dir)
+
+    planner.save('desi-status-{}.fits'.format(nightstr))
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Perform afternoon planning.',
+        epilog='EXAMPLE: %(prog)s --night 2020-01-01')
+    parser.add_argument('--night', type=str,
+                        help='night to plan, default: tonight',
+                        default=None)
+    parser.add_argument('--lastnight', type=str,
+                        help='night to restore, default: start fresh.',
+                        default=None)
+
+    args = parser.parse_args()
+    afternoon_plan(args.night, args.lastnight)

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -8,6 +8,7 @@ import glob
 import re
 import os
 import shutil
+import subprocess
 from desisurvey.scripts import collect_etc
 
 
@@ -137,12 +138,16 @@ def afternoon_plan(night=None, restore_etc_stats=None, configfn='config.yaml',
     tiles, exps = collect_etc.scan_directory(spectra_dir,
                                              start_from=restore_etc_stats)
     collect_etc.write_tile_exp(tiles, exps, os.path.join(
-        directory, 'etc_stats-{}.fits'.format(nightstr)))
+        directory, 'etc-stats-{}.fits'.format(nightstr)))
     planner.set_donefrac(tiles['TILEID'], tiles['DONEFRAC_ETC'],
                          tiles['LASTEXPID_ETC'])
 
     planner.afternoon_plan(night, fiber_assign_dir=fiber_assign_dir)
     planner.save('{}/desi-status-{}.fits'.format(nightstr, nightstr))
+    for fn in [newtilefn, newrulesfn, newconfigfn,
+               os.path.join(directory, 'desi-status-{}.fits'.format(nightstr)),
+               os.path.join(directory, 'etc-stats-{}.fits'.format(nightstr))]:
+        subprocess.run(['chmod', 'a-w', fn])
 
 
 def find_rules_file(file_name):

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -36,7 +36,6 @@ def afternoon_plan(night=None, lastnight=None, fiber_assign_dir=None,
     config = desisurvey.config.Configuration()
     tilesob = desisurvey.tiles.get_tiles(use_cache=False, write_cache=True)
     rules = desisurvey.rules.Rules(config.rules)
-    # should look for rules file in obsplan dir?
     if lastnight is not None:
         planner = desisurvey.plan.Planner(
             rules, restore='desi-status-{}.fits'.format(lastnight))

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -126,8 +126,6 @@ def afternoon_plan(night=None, restore_etc_stats=None, configfn='config.yaml',
     if os.path.exists(newrulesfn):
         log.error('{} already exists, failing!'.format(newrulesfn))
         return
-    shutil.copy(tilefn, newtilefn)
-    shutil.copy(rulesfn, newrulesfn)
 
     editedtiles = False
     editedrules = False
@@ -155,6 +153,9 @@ def afternoon_plan(night=None, restore_etc_stats=None, configfn='config.yaml',
         return
     with open(newconfigfn, 'w') as fp:
         fp.writelines(lines)
+
+    shutil.copy(tilefn, newtilefn)
+    shutil.copy(rulesfn, newrulesfn)
 
     desisurvey.config.Configuration.reset()
     config = desisurvey.config.Configuration(newconfigfn)

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -7,7 +7,7 @@ import os
 from desisurvey.scripts import collect_etc
 
 def afternoon_plan(night=None, lastnight=None, fiber_assign_dir=None,
-                   spectra_dir=None):
+                   spectra_dir=None, simulate=False):
     """
     Perform daily afternoon planning.
 
@@ -35,14 +35,14 @@ def afternoon_plan(night=None, lastnight=None, fiber_assign_dir=None,
     desisurvey.config.Configuration.reset()
     config = desisurvey.config.Configuration()
     tilesob = desisurvey.tiles.get_tiles(use_cache=False, write_cache=True)
-    rules = desisurvey.rules.Rules(config.rules)
+    rules = desisurvey.rules.Rules(config.rules())
     if lastnight is not None:
         planner = desisurvey.plan.Planner(
-            rules, restore='desi-status-{}.fits'.format(lastnight))
+            rules, restore='desi-status-{}.fits'.format(lastnight), simulate=simulate)
         scheduler = desisurvey.scheduler.Scheduler(
             restore='desi-status-{}.fits'.format(lastnight))
     else:
-        planner = desisurvey.plan.Planner(rules)
+        planner = desisurvey.plan.Planner(rules, simulate=simulate)
         scheduler = desisurvey.scheduler.Scheduler()
 
     nightstr = desisurvey.utils.night_to_str(night)

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -177,7 +177,9 @@ def afternoon_plan(night=None, restore_etc_stats=None, configfn='config.yaml',
     planner.save('{}/desi-status-{}.fits'.format(nightstr, nightstr))
 
 
-if __name__ == "__main__":
+def parse(options=None):
+    """Parse command-line options for running afternoon planning.
+    """
     import argparse
     parser = argparse.ArgumentParser(
         description='Perform afternoon planning.',
@@ -190,8 +192,14 @@ if __name__ == "__main__":
                         default=None)
     parser.add_argument('--config', type=str, default=None,
                         help='config file to use for night')
-    args = parser.parse_args()
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+    return args
 
+
+def main(args):
     outputdir = os.environ.get('DESISURVEY_OUTPUT', None)
     log = desiutil.log.get_logger()
     if outputdir is None:

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -1,14 +1,17 @@
 import os
 import glob
-import numpy
+import numpy as np
 from astropy.io import fits
+import desiutil.log
+
+log = desiutil.log.get_logger()
 
 
 class subslices:
     "Iterator for looping over subsets of an array"
     def __init__(self, data, uind=None):
         if uind is None:
-            self.uind = numpy.unique(data, return_index=True)[1]
+            self.uind = np.unique(data, return_index=True)[1]
         else:
             self.uind = uind.copy()
         self.ind = 0
@@ -35,7 +38,17 @@ class subslices:
         return self.__next__()
 
 
-def scan_directory(dirname):
+def cull_old_files(files, start_from):
+    """Return only subset of files with EXPID larger than any EXPID in 
+    start_from.
+    """
+    expid = np.array([int(os.path.basename(f)[5:13]) for f in files])
+    # extract just the expid; better to do this with a regex, but...
+    maxexpid = np.max(start_from['expid'])
+    return files[expid > maxmatch]
+
+
+def scan_directory(dirname, simulate_donefrac=False, start_from=None):
     """Scan directory for spectra with ETC statistics to collect.
 
     Parameters
@@ -45,40 +58,83 @@ def scan_directory(dirname):
         for ETC statistics.
         This needs to be updated to ~DESI files only, with more care given
         to where these keywords are actually found.
+    simulate_donefrac : bool
+        instead of tabulating DONEFRAC, tabulate EXPTIME / 1000 instead.
+        this is useful when DONEFRAC is not being computed.
+    start_from : str
+        etc_stats file to start from.  Nights already in the etc_stats file
+        will not be collected.  If a YYYMMDD string, look for etc_stats file
+        in DESISURVEY_OUTPUT/YYYYMMDD/etc_stats-{YYYYMMDD}.fits
     """
-    files = list(glob.iglob(os.path.join(dirname, '**/*.fits'),
-                            recursive=True))
-    exps = numpy.zeros(len(files), dtype=[
-        ('EXPID', 'i4'), ('FILENAME', 'U80'),
+    log.info('Scanning {} for desi exposures...'.format(dirname))
+    files = glob.glob(os.path.join(dirname, '**/desi*.fits.fz'),
+                      recursive=True)
+    if start_from is not None:
+        try:
+            fn = os.path.join(os.environ['DESISURVEY_OUTPUT'], start_from,
+                              'etc_stats-{}.fits'.format(start_from))
+            start_exps = fits.getdata(fn, 'EXPS')
+        except:
+            try:
+                start_exps = fits.getdata(start_from, 'EXPS')
+            except:
+                log.error('Could not find file {} to start from!'.format(
+                    start_from))
+                return
+        files = cull_old_files(files, start_exps)
+    else:
+        start_exps = None
+    
+    log.info('Found {} files, extracting header information...'.format(
+        len(files)))
+    exps = np.zeros(len(files), dtype=[
+        ('EXPID', 'i4'), ('FILENAME', 'U200'),
         ('TILEID', 'f4'), ('DONEFRAC_EXP_ETC', 'f4'),
         ('EXPTIME', 'f4'), ('MJD_OBS', 'f4'), ('FLAVOR', 'U80')])
     for i, fn in enumerate(files):
-        hdr = fits.getheader(fn)
+        if (i % 1000) == 0:
+            log.info('Extracting headers from file {} of {}...'.format(
+                i+1, len(files)))
+        hdr = {}
+        for ename in ['SPEC', 'SPS']:
+            try:
+                hdr = fits.getheader(fn, ename)
+                break
+            except:
+                continue
         exps['EXPID'][i] = hdr.get('EXPID', -1)
-        exps['FILENAME'][i] = os.path.basename(fn)
+        exps['FILENAME'][i] = hdr.get('filename', fn)
         exps['TILEID'][i] = hdr.get('TILEID', -1)
-        exps['DONEFRAC_EXP_ETC'][i] = hdr.get('DONEFRAC', -1)
+        if not simulate_donefrac:
+            exps['DONEFRAC_EXP_ETC'][i] = hdr.get('DONEFRAC', -1)
+        else:
+            exps['DONEFRAC_EXP_ETC'][i] = hdr.get('EXPTIME', -1)/1000
         exps['EXPTIME'][i] = hdr.get('EXPTIME', -1)
-        exps['MJD_OBS'][i] = hdr.get('MJD_OBS', -1)
+        exps['MJD_OBS'][i] = hdr.get('MJD-OBS', -1)
         exps['FLAVOR'][i] = hdr.get('FLAVOR', 'none')
-    flavors = numpy.array([f.upper().strip() for f in exps['FLAVOR']])
+    flavors = np.array([f.upper().strip() for f in exps['FLAVOR']])
     m = (exps['TILEID'] == -1) | (flavors != 'SCIENCE')
-    if numpy.any(m):
-        print('Ignoring %d files due to weird FLAVOR or TILEID' % numpy.sum(m))
+    if np.any(m):
+        log.info('Ignoring {} files due to weird FLAVOR or TILEID'.format(
+            np.sum(m)))
         exps = exps[~m]
-    ntiles = len(numpy.unique(exps['TILEID']))
-    tiles = numpy.zeros(ntiles, dtype=[
+    ntiles = len(np.unique(exps['TILEID']))
+    tiles = np.zeros(ntiles, dtype=[
         ('TILEID', 'i4'), ('DONEFRAC_ETC', 'f4'), ('EXPTIME', 'f4'),
-        ('LASTEXPID_ETC', 'f4'), ('NOBS_ETC', 'i4'), ('LASTMJD_ETC', 'f4')])
-    s = numpy.argsort(exps['TILEID'])
+        ('LASTEXPID_ETC', 'i4'), ('NOBS_ETC', 'i4'), ('LASTMJD_ETC', 'f4')])
+    s = np.argsort(exps['TILEID'])
     for i, (f, l) in enumerate(subslices(exps['TILEID'][s])):
         ind = s[f:l]
         tiles['TILEID'][i] = exps['TILEID'][ind[0]]
-        tiles['DONEFRAC_ETC'][i] = numpy.sum(exps['DONEFRAC_EXP_ETC'][ind])
-        tiles['EXPTIME'][i] = numpy.sum(exps['EXPTIME'][ind])
-        tiles['LASTEXPID_ETC'][i] = numpy.max(exps['EXPID'][ind])
+        tiles['DONEFRAC_ETC'][i] = np.sum(np.clip(
+            exps['DONEFRAC_EXP_ETC'][ind], 0, np.inf))
+        tiles['EXPTIME'][i] = np.sum(np.clip(
+            exps['EXPTIME'][ind], 0, np.inf))
+        tiles['LASTEXPID_ETC'][i] = np.max(exps['EXPID'][ind])
+        # potentially only want to consider "good" exposures here?
         tiles['NOBS_ETC'][i] = len(ind)
-        tiles['LASTMJD_ETC'][i] = numpy.max(exps['MJD_OBS'][ind])
+        tiles['LASTMJD_ETC'][i] = np.max(exps['MJD_OBS'][ind])
+    exps = exps[np.argsort(exps['EXPID'])]
     return tiles, exps
 
 
@@ -107,6 +163,8 @@ if __name__ == "__main__":
                         help='directory to scan for spectra')
     parser.add_argument('outfile', type=str,
                         help='file to write out')
+    parser.add_argument('--start_from', type=str, defalt=None,
+                        help='etc_stats file to start from')
     args = parser.parse_args()
     tiles, exps = scan_directory(args.directory)
     write_tile_exp(tiles, exps, args.outfile)

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -1,0 +1,92 @@
+import os
+import glob
+import numpy
+from astropy.io import fits
+
+
+class subslices:
+    "Iterator for looping over subsets of an array"
+    def __init__(self, data, uind=None):
+        if uind is None:
+            self.uind = numpy.unique(data, return_index=True)[1]
+        else:
+            self.uind = uind.copy()
+        self.ind = 0
+        self.length = len(data)
+
+    def __iter__(self):
+        return self
+
+    def __len__(self):
+        return len(self.uind)
+
+    def __next__(self):
+        if self.ind == len(self.uind):
+            raise StopIteration
+        if self.ind == len(self.uind)-1:
+            last = self.length
+        else:
+            last = self.uind[self.ind+1]
+        first = self.uind[self.ind]
+        self.ind += 1
+        return first, last
+
+    def next(self):
+        return self.__next__()
+
+
+def scan_directory(dirname):
+    files = list(glob.iglob(os.path.join(dirname, '**/*.fits'),
+                            recursive=True))
+    exps = numpy.zeros(len(files), dtype=[
+        ('EXPID', 'i4'), ('FILENAME', 'U80'),
+        ('TILEID', 'f4'), ('DONEFRAC_EXP_ETC', 'f4'),
+        ('EXPTIME', 'f4'), ('MJD_OBS', 'f4'), ('FLAVOR', 'U80')])
+    for i, fn in enumerate(files):
+        hdr = fits.getheader(fn)
+        exps['EXPID'][i] = hdr.get('EXPID', -1)
+        exps['FILENAME'][i] = os.path.basename(fn)
+        exps['TILEID'][i] = hdr.get('TILEID', -1)
+        exps['DONEFRAC_EXP_ETC'][i] = hdr.get('DONEFRAC', -1)
+        exps['EXPTIME'][i] = hdr.get('EXPTIME', -1)
+        exps['MJD_OBS'][i] = hdr.get('MJD_OBS', -1)
+        exps['FLAVOR'][i] = hdr.get('FLAVOR', 'none')
+    flavors = numpy.array([f.upper().strip() for f in exps['FLAVOR']])
+    m = (exps['TILEID'] == -1) | (flavors != 'SCIENCE')
+    if numpy.any(m):
+        print('Ignoring %d files due to weird FLAVOR or TILEID' % numpy.sum(m))
+        exps = exps[~m]
+    ntiles = len(numpy.unique(exps['TILEID']))
+    tiles = numpy.zeros(ntiles, dtype=[
+        ('TILEID', 'i4'), ('DONEFRAC_ETC', 'f4'), ('EXPTIME', 'f4'),
+        ('LASTEXPID_ETC', 'f4'), ('NOBS_ETC', 'i4'), ('LASTMJD_ETC', 'f4')])
+    s = numpy.argsort(exps['TILEID'])
+    for i, (f, l) in enumerate(subslices(exps['TILEID'][s])):
+        ind = s[f:l]
+        tiles['TILEID'][i] = exps['TILEID'][ind[0]]
+        tiles['DONEFRAC_ETC'][i] = numpy.sum(exps['DONEFRAC_EXP_ETC'][ind])
+        tiles['EXPTIME'][i] = numpy.sum(exps['EXPTIME'][ind])
+        tiles['LASTEXPID_ETC'][i] = numpy.max(exps['EXPID'][ind])
+        tiles['NOBS_ETC'][i] = len(ind)
+        tiles['LASTMJD_ETC'][i] = numpy.max(exps['MJD_OBS'][ind])
+    return tiles, exps
+
+
+def write_tile_exp(tiles, exps, fn):
+    from astropy.io import fits
+    fits.writeto(fn, tiles)
+    fits.append(fn, tiles)
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Collect ETC statistics from spectra.',
+        epilog='EXAMPLE: %(prog)s directory outfile')
+    parser.add_argument('directory', type=str,
+                        help='directory to scan for spectra')
+    parser.add_argument('outfile', type=str,
+                        help='file to write out')
+    args = parser.parse_args()
+    tiles, exps = scan_directory(args.directory)
+    write_tile_exp(tiles, exps, args.outfile)

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -103,7 +103,7 @@ def scan_directory(dirname, simulate_donefrac=False, start_from=None):
                 break
         files = cull_old_files(files, start_exps)
     
-    log.info('Found {} files, extracting header information...'.format(
+    log.info('Found {} new raw spectra, extracting header information...'.format(
         len(files)))
     exps = np.zeros(len(files), dtype=[
         ('EXPID', 'i4'), ('FILENAME', 'U200'),

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -219,8 +219,11 @@ if __name__ == "__main__":
                         help='file to write out')
     parser.add_argument('--start_from', type=str, default=None,
                         help='etc_stats file to start from')
+    parser.add_argument('--simulate_donefrac', action='store_true',
+                        help='use exptime/1000 instead of DONEFRAC')
     args = parser.parse_args()
-    res = scan_directory(args.directory, start_from=args.start_from)
+    res = scan_directory(args.directory, start_from=args.start_from,
+                         simulate_donefrac=args.simulate_donefrac)
     if res is not None:
         tiles, exps = res
         write_tile_exp(tiles, exps, args.outfile)

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -36,6 +36,16 @@ class subslices:
 
 
 def scan_directory(dirname):
+    """Scan directory for spectra with ETC statistics to collect.
+
+    Parameters
+    ----------
+    dirname : str
+        directory path to scan.  All fits files under dirname are searched
+        for ETC statistics.
+        This needs to be updated to ~DESI files only, with more care given
+        to where these keywords are actually found.
+    """
     files = list(glob.iglob(os.path.join(dirname, '**/*.fits'),
                             recursive=True))
     exps = numpy.zeros(len(files), dtype=[
@@ -73,6 +83,16 @@ def scan_directory(dirname):
 
 
 def write_tile_exp(tiles, exps, fn):
+    """Write tile & exposure ETC statistics from numpy objects.
+
+    Parameters
+    ----------
+    tiles : array
+        tile ETC statistics
+
+    exps : array
+        exposure ETC statistics
+    """
     from astropy.io import fits
     fits.writeto(fn, tiles, header=fits.Header(dict(EXTNAME='TILES')))
     fits.append(fn, exps, header=fits.Header(dict(EXTNAME='EXPS')))

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -208,7 +208,7 @@ def read_tile_exp(fn):
     return convert_fits(tiles), convert_fits(exps)
 
 
-if __name__ == "__main__":
+def parse(options=None):
     import argparse
     parser = argparse.ArgumentParser(
         description='Collect ETC statistics from spectra.',
@@ -221,9 +221,19 @@ if __name__ == "__main__":
                         help='etc_stats file to start from')
     parser.add_argument('--simulate_donefrac', action='store_true',
                         help='use exptime/1000 instead of DONEFRAC')
-    args = parser.parse_args()
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+
+    return args
+
+
+def main(args):
     res = scan_directory(args.directory, start_from=args.start_from,
                          simulate_donefrac=args.simulate_donefrac)
     if res is not None:
         tiles, exps = res
         write_tile_exp(tiles, exps, args.outfile)
+    else:
+        raise ValueError('Could not collect ETC files.')

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -74,8 +74,8 @@ def scan_directory(dirname):
 
 def write_tile_exp(tiles, exps, fn):
     from astropy.io import fits
-    fits.writeto(fn, tiles)
-    fits.append(fn, tiles)
+    fits.writeto(fn, tiles, header=fits.Header(dict(EXTNAME='TILES')))
+    fits.append(fn, exps, header=fits.Header(dict(EXTNAME='EXPS')))
 
 
 if __name__ == "__main__":

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -95,7 +95,7 @@ def scan_directory(dirname, simulate_donefrac=False, start_from=None):
             expids = [re.findall(r'-(\d+)\.', os.path.basename(f)) for f
                       in files0]
             if len(expids) == 0:
-                log.info(f'No desi exposures on night {subdir}')
+                log.info('No desi exposures on night {}'.format(subdir))
                 continue
             expids = [int(expid[0]) for expid in expids if len(expid) > 0]
             files += files0

--- a/py/desisurvey/scripts/surveyinit.py
+++ b/py/desisurvey/scripts/surveyinit.py
@@ -157,6 +157,7 @@ def calculate_initial_plan(args):
     design['INIT'] = np.zeros(tiles.ntiles)
     design['HA'] = np.zeros(tiles.ntiles)
     design['TEXP'] = np.zeros(tiles.ntiles)
+    design['TILEID'] = tiles.tileID
 
     # Optimize each program separately.
     stretches = dict(

--- a/py/desisurvey/scripts/surveymovie.py
+++ b/py/desisurvey/scripts/surveymovie.py
@@ -146,14 +146,14 @@ class Animator(object):
         # We require a standard set of passes.
         if not np.array_equal(self.tiles.passes, np.arange(8)):
             raise RuntimeError('Expected passes 0-7.')
-        self.prognames = ['DARK', 'DARK', 'DARK', 'DARK', 'GRAY',
+        self.prognames = ['GRAY', 'DARK', 'DARK', 'DARK', 'DARK',
                           'BRIGHT', 'BRIGHT', 'BRIGHT']
         npass = np.max(self.passnum) + 1
         self.tiles_per_pass = self.tiles.pass_ntiles
         self.psels = [
-            self.passnum < 4,  # DARK
-            self.passnum == 4, # GRAY
-            self.passnum > 4,  # BRIGHT
+            self.tiles.program_mask['DARK'],  # DARK
+            self.tiles.program_mask['GRAY'],  # GRAY
+            self.tiles.program_mask['BRIGHT'],  # BRIGHT
         ]
         self.start_date = self.config.first_day()
         self.survey_weeks = int(np.ceil((self.config.last_day() - self.start_date).days / 7))

--- a/py/desisurvey/test/test_plan.py
+++ b/py/desisurvey/test/test_plan.py
@@ -16,10 +16,10 @@ class TestPlan(Tester):
         completed = np.zeros(tiles.ntiles, bool)
         num_nights = (self.stop - self.start).days
         gen = np.random.RandomState(123)
-        config = desisurvey.config.Configuration(simulate=True)
+        config = desisurvey.config.Configuration()
         for cadence in 'daily', 'monthly':
             config.fiber_assignment_cadence.set_value(cadence)
-            plan = Planner()
+            plan = Planner(simulate=True)
             plan2 = None
             for i in range(num_nights):
                 night = self.start + datetime.timedelta(i)

--- a/py/desisurvey/test/test_plan.py
+++ b/py/desisurvey/test/test_plan.py
@@ -24,7 +24,8 @@ class TestPlan(Tester):
             for i in range(num_nights):
                 night = self.start + datetime.timedelta(i)
                 # Run afternoon plan using original and restored objects.
-                avail, pri = plan.afternoon_plan(night, completed)
+                avail, pri = plan.afternoon_plan(night, completed,
+                                                 simulate=True)
                 if plan2 is not None:
                     # Check that the restored planner gives identical results.
                     avail2, pri2 = plan2.afternoon_plan(night, completed)

--- a/py/desisurvey/test/test_plan.py
+++ b/py/desisurvey/test/test_plan.py
@@ -33,10 +33,10 @@ class TestPlan(Tester):
                     self.assertTrue(np.array_equal(plan.tile_countdown, plan2.tile_countdown))
                 # Mark a random set of tiles completed after this night.
                 completed[gen.choice(tiles.ntiles, tiles.ntiles // num_nights)] = True
-                plan.set_donefrac(tiles['tileID'], completed, np.zeros(len(tiles)))
+                plan.set_donefrac(tiles.tileID, completed, np.zeros(tiles.ntiles))
                 # Save and restore our state.
                 plan.save('snapshot.fits')
-                plan2 = Planner(restore='snapshot.fits')
+                plan2 = Planner(restore='snapshot.fits', simulate=True)
 
 
 def test_suite():

--- a/py/desisurvey/test/test_plan.py
+++ b/py/desisurvey/test/test_plan.py
@@ -16,7 +16,7 @@ class TestPlan(Tester):
         completed = np.zeros(tiles.ntiles, bool)
         num_nights = (self.stop - self.start).days
         gen = np.random.RandomState(123)
-        config = desisurvey.config.Configuration()
+        config = desisurvey.config.Configuration(simulate=True)
         for cadence in 'daily', 'monthly':
             config.fiber_assignment_cadence.set_value(cadence)
             plan = Planner()
@@ -24,16 +24,16 @@ class TestPlan(Tester):
             for i in range(num_nights):
                 night = self.start + datetime.timedelta(i)
                 # Run afternoon plan using original and restored objects.
-                avail, pri = plan.afternoon_plan(night, completed,
-                                                 simulate=True)
+                avail, pri = plan.afternoon_plan(night)
                 if plan2 is not None:
                     # Check that the restored planner gives identical results.
-                    avail2, pri2 = plan2.afternoon_plan(night, completed)
+                    avail2, pri2 = plan2.afternoon_plan(night)
                     self.assertTrue(np.array_equal(avail, avail2))
                     self.assertTrue(np.array_equal(pri, pri2))
                     self.assertTrue(np.array_equal(plan.tile_countdown, plan2.tile_countdown))
                 # Mark a random set of tiles completed after this night.
                 completed[gen.choice(tiles.ntiles, tiles.ntiles // num_nights)] = True
+                plan.set_donefrac(tiles['tileID'], completed, np.zeros(len(tiles)))
                 # Save and restore our state.
                 plan.save('snapshot.fits')
                 plan2 = Planner(restore='snapshot.fits')

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -30,7 +30,8 @@ class TestScheduler(Tester):
             self.assertTrue(np.all(scheduler.snr2frac == scheduler2.snr2frac))
             self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
             self.assertTrue(np.all(scheduler.completed_by_pass == scheduler2.completed_by_pass))
-            avail, pri = planner.afternoon_plan(night, scheduler.completed)
+            avail, pri = planner.afternoon_plan(night, scheduler.completed,
+                                                simulate=True)
             # Run both schedulers in parallel.
             scheduler.update_tiles(avail, pri)
             scheduler.init_night(night)

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -19,7 +19,7 @@ class TestScheduler(Tester):
         surveyinit.main(args)
         config = desisurvey.config.Configuration()
         config.fiber_assignment_cadence.set_value('daily')
-        planner = desisurvey.plan.Planner()
+        planner = desisurvey.plan.Planner(simulate=True)
         scheduler = Scheduler()
         num_nights = (self.stop - self.start).days
         for i in range(num_nights):
@@ -30,8 +30,7 @@ class TestScheduler(Tester):
             self.assertTrue(np.all(scheduler.snr2frac == scheduler2.snr2frac))
             self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
             self.assertTrue(np.all(scheduler.completed_by_pass == scheduler2.completed_by_pass))
-            avail, pri = planner.afternoon_plan(night, scheduler.completed,
-                                                simulate=True)
+            avail, pri = planner.afternoon_plan(night, scheduler.completed)
             # Run both schedulers in parallel.
             scheduler.update_tiles(avail, pri)
             scheduler.init_night(night)

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -6,6 +6,7 @@ import numpy as np
 import desisurvey.plan
 import desisurvey.etc
 import desisurvey.config
+import desisurvey.utils
 from desisurvey.test.base import Tester
 from desisurvey.scripts import surveyinit
 from desisurvey.scheduler import Scheduler
@@ -20,12 +21,14 @@ class TestScheduler(Tester):
         config = desisurvey.config.Configuration()
         config.fiber_assignment_cadence.set_value('daily')
         planner = desisurvey.plan.Planner(simulate=True)
+        planner.first_night = desisurvey.utils.get_date('2020-01-01')
+        planner.last_night = desisurvey.utils.get_date('2025-01-01')
         scheduler = Scheduler()
         num_nights = (self.stop - self.start).days
         for i in range(num_nights):
             night = self.start + datetime.timedelta(i)
             # Save and restore scheduler state.
-            scheduler.save('snapshot.fits')
+            planner.save('snapshot.fits')
             scheduler2 = Scheduler(restore='snapshot.fits')
             self.assertTrue(np.all(scheduler.snr2frac == scheduler2.snr2frac))
             self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
@@ -48,8 +51,9 @@ class TestScheduler(Tester):
                     self.assertEqual(field, field2)
                 tileid = next[0]                
                 if tileid is not None:
-                    scheduler.update_snr(tileid, 1.)
-                    scheduler2.update_snr(tileid, 1.)
+                    scheduler.update_snr(tileid, 1., 0)
+                    scheduler2.update_snr(tileid, 1., 0)
+                planner.set_donefrac(scheduler.tiles.tileID, scheduler.snr2frac, 0*scheduler.snr2frac)
 
 
 def test_suite():

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -171,6 +171,7 @@ class Tiles(object):
         scalar = np.isscalar(tileID)
         tileID = np.atleast_1d(tileID)
         idx = np.searchsorted(self.tileID, tileID)
+        idx = np.clip(idx, 0, len(self.tileID)-1)
         bad = self.tileID[idx] != tileID
         if not return_mask and np.any(bad):
             raise ValueError('Invalid tile ID(s): {}.'.format(tileID[bad]))

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -67,6 +67,7 @@ class Tiles(object):
         self.passnum = tiles['PASS'].copy()
         self.tileRA = tiles['RA'].copy()
         self.tileDEC = tiles['DEC'].copy()
+        self.tileobsconditions = tiles['OBSCONDITIONS'].copy()
         # Count tiles.
         self.ntiles = len(self.tileID)
         self.pass_ntiles = {p: np.count_nonzero(self.passnum == p)
@@ -106,6 +107,10 @@ class Tiles(object):
             for pnum in self.program_passes[p]:
                 mask |= (self.passnum == pnum)
             self.program_mask[p] = mask
+        self.allowed_in_conditions = {}
+        for p in self.OBSCONDITIONS:
+            mask = (self.tileobsconditions & self.OBSCONDITIONS[p]) != 0
+            self.allowed_in_conditions[p] = mask
         # Calculate and save dust exposure factors.
         self.dust_factor = desisurvey.etc.dust_exposure_factor(tiles['EBV_MED'])
         # Precompute coefficients to calculate tile observing airmass.
@@ -127,6 +132,13 @@ class Tiles(object):
 
     Note that this mapping is independent of the programs actually present
     in a tiles file.
+    """
+
+    OBSCONDITIONS = {'DARK': 1, 'GRAY': 2, 'BRIGHT': 4}
+    """Mapping of night conditions to OBSCONDITIONS bit mask.
+
+    Tiles that may be observed in DARK/GRAY/BRIGHT conditions should have
+    (obsconditions & OBSCONDITIONS[program]) != 0.
     """
 
     def airmass(self, hour_angle, mask=None):

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -237,6 +237,10 @@ def local_noon_on_date(day):
 
 def get_current_date():
     """Give current date following get_date convention (date changes at noon).
+
+    Returns
+    -------
+    datetime.date object for current night, following get_date convention
     """
     date = datetime.datetime.now().astimezone()
     return get_date(date)
@@ -325,6 +329,21 @@ def get_date(date):
     if not isinstance(date, datetime.date):
         raise ValueError('Invalid date specification: {0}.'.format(input_date))
     return date
+
+
+def night_to_str(date):
+    """Return DESI string format (YYYYMMDD) of datetime night.
+
+    Parameters
+    ----------
+    date : datetime.date object, as from get_date()
+
+    Returns
+    -------
+    str
+        YYYMMDD formatted date string
+    """
+    return date.isoformat().replace('-', '')
 
 
 def day_number(date):

--- a/py/desisurvey/utils.py
+++ b/py/desisurvey/utils.py
@@ -235,6 +235,13 @@ def local_noon_on_date(day):
     return astropy.time.Time(utc_noon)
 
 
+def get_current_date():
+    """Give current date following get_date convention (date changes at noon).
+    """
+    date = datetime.datetime.now().astimezone()
+    return get_date(date)
+
+
 def get_date(date):
     """Convert different date specifications into a datetime.date object.
 


### PR DESCRIPTION
This PR and an associated one on surveysim reorganizes the desisurvey plan & scheduler state files into a single state file.  It also adds rudimentary afternoon planning code which scans for DESI spectra for ETC information and fiberassign directories for available tiles, but I will need to revisit the details of these bits once NERSC is back up.  Finally, it allows the derived available exposure & status files to no longer exactly match the tile file---i.e., if we have some weird commissioning TILEIDs, or if we change tile files, etc., that should not cause any issues.

There are also a few miscellaneous changes, like letting NTS be passed an "azrange" argument, which limits selected tiles to a particular azimuth range.

This PR does not make any changes to the actual survey simulations; the same tiles get scheduled at the same times.

The associated PR on surveysim updates surveysim to use the slightly changed API in this patch, primarily to desisurvey.plan.Plan, which now is instantiated with a simulate=True argument if simulated fiber assignment is desired, and which now uses the single state file when --save-restore is requested.

There's more to do here.  Some points for discussion:
* I'm now imagining that each night's desisurvey configuration is a config.yaml file and a status file.  The config file also specifies the rules.yaml file to be used for that night.  I can imagine the config.yaml file changing over the course of the survey, and so checking these in and making them a part of the history of the planning of each night seems sensible to me.  On the other hand, a lot of the information in config.yaml is not particularly variable.
* NTS currently only avoids rescheduling via QueuedList and makes no attempt to keep state up to date otherwise (i.e., tile completion and donefrac statistics).  The assumption is that these will get updated during the next afternoon planning sequence.
* The nightly planning files are then currently:
  1. config.yaml
  2. rules.yaml
  3. queued-YYMMDD.csv
  4. desi-status-YYMMDD.csv
* These files are currently dropped in DESISURVEY_OUTPUT, though I'll push everything into a DESISURVEY_OUTPUT/YYMMDD directory soon.
* I'm imagining the state files get produced by afternoon planning and then are never touched each night.  They can safely be checked in and forgotten about.  Afternoon planning will then need to gain some smarts about checking out and parsing other human files overriding nominal completeness statistics from the ETC/offline pipeline/...
* Currently, all DESI files get scanned for ETC headers each night.  We should consider less redundant alternatives.

The equivalent PR on surveysim currently fails testing because it depends on the new API.  I'm not sure how to tell CI that it needs to test relative to a special branch.