### PR TITLE
Change fiber_assignment_order to reflect new pass ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ env:
         - SPECLITE_VERSION=0.8
         - SPECSIM_VERSION=v0.13
         # - SPECTER_VERSION=0.6.0
-        - DESIMODEL_VERSION=0.10.3
-        - DESIMODEL_DATA=branches/test-0.10
+        - DESIMODEL_VERSION=0.12.0
+        - DESIMODEL_DATA=branches/test-0.12
         # - HARP_VERSION=1.0.1
         # - SPECEX_VERSION=0.3.9
         - MAIN_CMD='python setup.py'

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -134,11 +134,9 @@ fiber_assignment_cadence: monthly
 # Similarly, a delay of 0 indicates that fibers are assigned on
 # the first day / month after the covering tiles are completed.
 fiber_assignment_order:
-    P1: P0 delay 1
-    P2: P0+P1 delay 1
-    P3: P0+P1 delay 1
-    P6: P5 delay 1
-    P7: P5+P6 delay 1
+    P2: P1 delay 1
+    P3: P1+P2 delay 1
+    P4: P1+P2 delay 1
 
 # Nominal tile radius for determining whether two tiles overlap.
 tile_radius: 1.63 deg


### PR DESCRIPTION
The new tile file changed the pass ordering.  This PR changes the config file to reflect that change.  It also removes the fiber_assignment_order constraints from the BGS/MWS surveys, since I do not believe they intend to impose such constraints.