### PR TITLE
Update default rules.yaml to use new tile file pass ordering.

### DIFF
--- a/py/desisurvey/data/rules.yaml
+++ b/py/desisurvey/data/rules.yaml
@@ -3,36 +3,36 @@
 # and prioritized. See doc/rules.rst for an explanation for the format.
 #-------------------------------------------------------------------
 
-# 15 < DEC < 25 stripe in NGC. Our goal is to observe this strip in DARK-0,1
-# GRAY-4 and BRIGHT-5,6 in year-1, then observe DARK-2,3 and BRIGHT-7 in year-2,
+# 15 < DEC < 25 stripe in NGC. Our goal is to observe this strip in DARK-1,2
+# GRAY-0 and BRIGHT-5,6 in year-1, then observe DARK-3,4 and BRIGHT-7 in year-2,
 # resulting in full depth for all programs by the end of year-2.
 N10:
     cap: N
     dec_min: 15
     dec_max: 25
     dec_order: +0.2
-    passes: 2,3,4,7
+    passes: 0,3,4,7
     rules:
-        N10(2): { N10LO(0): 0.8, N10HI(0): 1.0 }
-        N10(3): { N10LO(0): 0.6, N10HI(0): 0.8, N10(2): 1.0 }
-        N10(4): { START: 1.0 }
+        N10(0): { START: 1.0 }
+        N10(3): { N10LO(1): 0.8, N10HI(1): 1.0 }
+        N10(4): { N10LO(1): 0.6, N10HI(1): 0.8, N10(3): 1.0 }
         N10(7): { N10LO(5): 0.8, N10HI(5): 1.0 }
 
-# Pass-1 tiles in N10 need to cover passes 2, 3 for fiber assignment.
+# Pass-2 tiles in N10 need to cover passes 3, 4 for fiber assignment.
+N10P2:
+    covers: N10(3)+N10(4)
+    dec_order: +0.2
+    passes: 2
+    rules:
+        N10P2(2): { START: 0.8, N10P1(1): 1.0 }
+
+# Pass-1 tiles in N10 need to cover passes 2, 3, 4 for fiber assignment.
 N10P1:
-    covers: N10(2)+N10(3)
+    covers: N10P2(2)+N10(3)+N10(4)
     dec_order: +0.2
     passes: 1
     rules:
-        N10P1(1): { START: 0.8, N10P0(0): 1.0 }
-
-# Pass-0 tiles in N10 need to cover passes 1, 2, 3 for fiber assignment.
-N10P0:
-    covers: N10P1(1)+N10(2)+N10(3)
-    dec_order: +0.2
-    passes: 0
-    rules:
-        N10P0(0): { START: 1.0 }
+        N10P1(1): { START: 1.0 }
 
 # Pass-6 tiles in N10 need to cover pass 7 for fiber assignment.
 N10P6:
@@ -59,11 +59,11 @@ N10LO:
     max_orphans: 4
     passes: 0,1,2,3,4,5,6,7
     rules:
-        N10LO(0): { START: 0.7, N10P1(1): 1.0 }
-        N10LO(1): { N10HI(0): 0.6, N10(3): 1.0 }
-        N10LO(2): { N10HI(1): 1.0 }
-        N10LO(3): { N10HI(1): 1.0 }
-        N10LO(4): { START: 0.6, N10(4): 1.0 }
+        N10LO(0): { START: 0.6, N10(0): 1.0 }
+        N10LO(1): { START: 0.7, N10P2(2): 1.0 }
+        N10LO(2): { N10HI(1): 0.6, N10(4): 1.0 }
+        N10LO(3): { N10HI(2): 1.0 }
+        N10LO(4): { N10HI(2): 1.0 }
         N10LO(5): { START: 0.6, N10P6(6): 1.0 }
         N10LO(6): { N10HI(5): 0.6, N10(7): 1.0 }
         N10LO(7): { N10HI(6): 1.0 }
@@ -76,11 +76,11 @@ N10HI:
     dec_order: +0.2
     passes: 0,1,2,3,4,5,6,7
     rules:
-        N10HI(0): { START: 0.3, N10LO(0): 0.6, N10P1(1): 1.0 }
-        N10HI(1): { N10HI(0): 0.4, N10(3): 0.8, N10LO(1): 1.0 }
-        N10HI(2): { N10HI(1): 0.8, N10LO(2): 1.0 }
-        N10HI(3): { N10HI(1): 0.8, N10LO(3): 1.0 }
-        N10HI(4): { START: 0.4, N10(4): 0.8, N10LO(4): 1.0 }
+        N10HI(0): { START: 0.4, N10(0): 0.8, N10LO(0): 1.0 }
+        N10HI(1): { START: 0.3, N10LO(1): 0.6, N10P2(2): 1.0 }
+        N10HI(2): { N10HI(1): 0.4, N10(4): 0.8, N10LO(2): 1.0 }
+        N10HI(3): { N10HI(2): 0.8, N10LO(3): 1.0 }
+        N10HI(4): { N10HI(2): 0.8, N10LO(4): 1.0 }
         N10HI(5): { START: 0.4, N10P6(6): 0.8, N10LO(4): 1.0 }
         N10HI(6): { N10(7): 0.8, N10LO(6): 1.0 }
         N10HI(7): { N10HI(6): 0.8, N10LO(7): 1.0 }
@@ -94,10 +94,10 @@ SLO:
     passes: 0,1,2,3,4,5,6,7
     rules:
         SLO(0): { START: 1.0 }
-        SLO(1): { START: 0.5, SLO(0): 1.0 }
-        SLO(2): { SLO(0): 0.5, SLO(1): 1.0 }
+        SLO(1): { START: 1.0 }
+        SLO(2): { START: 0.5, SLO(1): 1.0 }
         SLO(3): { SLO(1): 0.5, SLO(2): 1.0 }
-        SLO(4): { START: 1.0 }
+        SLO(4): { SLO(2): 0.5, SLO(3): 1.0 }
         SLO(5): { START: 1.0 }
         SLO(6): { START: 0.5, SLO(5): 1.0 }
         SLO(7): { SLO(5): 0.5, SLO(6): 1.0 }
@@ -111,10 +111,10 @@ SHI:
     passes: 0,1,2,3,4,5,6,7
     rules:
         SHI(0): { START: 0.5, SLO(0): 1.0 }
-        SHI(1): { SLO(0): 0.5, SLO(1): 1.0 }
+        SHI(1): { START: 0.5, SLO(1): 1.0 }
         SHI(2): { SLO(1): 0.5, SLO(2): 1.0 }
         SHI(3): { SLO(2): 0.5, SLO(3): 1.0 }
-        SHI(4): { START: 0.5, SLO(4): 1.0 }
+        SHI(4): { SLO(3): 0.5, SLO(4): 1.0 }
         SHI(5): { START: 0.5, SLO(5): 1.0 }
         SHI(6): { SLO(5): 0.5, SLO(6): 1.0 }
         SHI(7): { SLO(6): 0.5, SLO(7): 1.0 }

--- a/py/desisurvey/scripts/surveymovie.py
+++ b/py/desisurvey/scripts/surveymovie.py
@@ -146,13 +146,13 @@ class Animator(object):
         # We require a standard set of passes.
         if not np.array_equal(self.tiles.passes, np.arange(8)):
             raise RuntimeError('Expected passes 0-7.')
-        self.prognames = ['DARK', 'DARK', 'DARK', 'DARK', 'GRAY',
+        self.prognames = ['GRAY', 'DARK', 'DARK', 'DARK', 'DARK',
                           'BRIGHT', 'BRIGHT', 'BRIGHT']
         npass = np.max(self.passnum) + 1
         self.tiles_per_pass = self.tiles.pass_ntiles
         self.psels = [
-            self.passnum < 4,  # DARK
-            self.passnum == 4, # GRAY
+            (self.passnum <= 4) & (self.passnum > 0),  # DARK
+            self.passnum == 0, # GRAY
             self.passnum > 4,  # BRIGHT
         ]
         self.start_date = self.config.first_day()


### PR DESCRIPTION
When we updated the tile file we changed the pass ordering of the passes and the pass <-> program mapping.  This doesn't matter for the "depth" rules, but it does for the default ~breadth first rules.  This PR attempts to update the default rules file to use the new pass ordering.

I'd appreciate it if someone else could inspect this for sanity.  I've just blindly tried to replace references to passes with the appropriate new numbers and verified that a surveysim run looks sane, but I don't follow the logic in this rules file well, so it was mostly a matter of symbol manipulation for me.