### PR TITLE
Fix transparency and seeing in exposure factor and ETC computations

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,8 @@ desisurvey change log
 0.15.1 (unreleased)
 -------------------
 
-* No changes yet
+* Fix bug in transparency and ETC snr2 accumulation rate calculation
+  (PR `#128`_)
 
 0.15.0 (2021-02-15)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,8 @@ desisurvey change log
 * Fix bug in transparency and ETC snr2 accumulation rate calculation
   (PR `#128`_)
 
+.. _`#128`: https://github.com/desihub/desisurvey/pull/128
+
 0.15.0 (2021-02-15)
 -------------------
 

--- a/py/desisurvey/etc.py
+++ b/py/desisurvey/etc.py
@@ -455,7 +455,7 @@ class ExposureTimeCalculator(object):
         # Estimate SNR2 to integrate in the next exposure.
         self.snr2frac_target = snr2frac + (texp_remaining / nexp) / self.texp_total
         # Initialize signal and background rate factors.
-        self.srate0 = self.weather_factor(seeing, transp)
+        self.srate0 = np.sqrt(self.weather_factor(seeing, transp))
         self.brate0 = sky
         self.signal = 0.
         self.background = 0.
@@ -493,7 +493,7 @@ class ExposureTimeCalculator(object):
         """
         dt = mjd_now - self.mjd_last
         self.mjd_last = mjd_now
-        srate = self.weather_factor(seeing, transp)
+        srate = np.sqrt(self.weather_factor(seeing, transp))
         brate = sky
         self.signal += dt * srate / self.srate0
         #self.background += dt * (srate + brate) / (self.srate0 + self.brate0)

--- a/py/desisurvey/etc.py
+++ b/py/desisurvey/etc.py
@@ -345,7 +345,7 @@ class ExposureTimeCalculator(object):
         transp : float
             Atmospheric transparency in the range (0,1).
         """
-        return transp * (self.seeing_coefs[0] + seeing * (self.seeing_coefs[1] + seeing * self.seeing_coefs[2])) ** 2
+        return (transp * (self.seeing_coefs[0] + seeing * (self.seeing_coefs[1] + seeing * self.seeing_coefs[2]))) ** 2
 
     def estimate_exposure(self, program, snr2frac, exposure_factor, nexp_completed=0):
         """Estimate exposure time(s).


### PR DESCRIPTION
There was a small bug in the signal accumulation rate in the ETC.  This PR fixes that, replacing the signal accumulation rate with the square root of the weather factor, rather than the weather factor.  This PR also changes the transparency to be the square of the transparency in the weather factor.

In combination with a related PR on surveysim, this slightly improves survey margin.  That's a bit of a surprise, since the transparency fix makes things strictly worse, but the bug in the survey simulations more than compensates.

Original margin:
![image](https://user-images.githubusercontent.com/1417841/109859711-23fd7200-7c12-11eb-8e5e-5a8d10deb15f.png)
New margin:
![image](https://user-images.githubusercontent.com/1417841/109859795-38da0580-7c12-11eb-87be-52f1684d8c40.png)

The fix to the srate in the ETC looks like it should have a huge impact, but its effect was muted since it only effects how survey speed varies within an exposure; the bug didn't affect the initial expectations of how long an exposure should last from the scheduler---though those were affected by the transparency issue.