### PR TITLE
Include sky in desisurvey.etc

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,13 @@ desisurvey change log
 0.15.1 (unreleased)
 -------------------
 
+* Use sky levels in ETC.  Use EFFTIME rather than R_DEPTH, and harmonize
+  MW extinction correction with EFFTIME.  (PR `#129`_)
 * Fix bug in transparency and ETC snr2 accumulation rate calculation
   (PR `#128`_)
 
 .. _`#128`: https://github.com/desihub/desisurvey/pull/128
+.. _`#129`: https://github.com/desihub/desisurvey/pull/129
 
 0.15.0 (2021-02-15)
 -------------------

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -84,6 +84,9 @@ same_field_setup : 60 s
 # Maximum time allowed for a single exposure before we force a cosmic split.
 cosmic_ray_split: 20 min
 
+# Maximum time to spend on one tile in a night
+maxtime: 1 hr
+
 # Minimum number of consecutive exposures required for cosmic rejection.
 min_exposures: 2
 
@@ -99,6 +102,11 @@ nominal_conditions:
     airmass: 1.0
     transparency: 1.0
     EBV: 0.0
+
+moon_up_factor:
+    DARK: 1.0
+    GRAY: 1.1
+    BRIGHT: 1.33
 
 # Reobserve tiles that have not reached this fraction of their target SNR**2.
 # Keep this at one until we simulate errors in ETC integration.

--- a/py/desisurvey/etc.py
+++ b/py/desisurvey/etc.py
@@ -83,7 +83,8 @@ def dust_exposure_factor(EBV):
     """Scaling of exposure time with median E(B-V) relative to nominal.
 
     The model uses the SDSS-g extinction coefficient (3.303) from Table 6
-    of Schlafly & Finkbeiner 2011.
+    of Schlafly & Finkbeiner 2011 by default, or config.ebv_coefficient if
+    specified.
 
     Parameters
     ----------
@@ -99,7 +100,12 @@ def dust_exposure_factor(EBV):
     EBV = np.asarray(EBV)
     config = desisurvey.config.Configuration()
     EBV0 = config.nominal_conditions.EBV()
-    Ag = 3.303 * (EBV - EBV0)
+    coeff = getattr(config, 'ebv_coefficient', None)
+    if coeff is not None:
+        coeff = coeff()
+    else:
+        coeff = 3.303
+    Ag = coeff * (EBV - EBV0)
     return np.power(10.0, (2.0 * Ag / 2.5))
 
 

--- a/py/desisurvey/etc.py
+++ b/py/desisurvey/etc.py
@@ -58,7 +58,7 @@ def seeing_exposure_factor(seeing):
 def transparency_exposure_factor(transparency):
     """Scaling of exposure time with transparency relative to nominal.
 
-    The model is that exposure time scales with 1 / transparency.
+    The model is that exposure time scales with 1 / transparency**2.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ def transparency_exposure_factor(transparency):
         raise ValueError('Got invalid transparency value <= 0.')
     config = desisurvey.config.Configuration()
     nominal = config.nominal_conditions.transparency()
-    return nominal / transparency
+    return (nominal / transparency)**2
 
 
 def dust_exposure_factor(EBV):
@@ -315,25 +315,17 @@ class ExposureTimeCalculator(object):
             self.log.warning(
                 'Unrecognized program {}, '.format(' '.join(unknownprograms)) +
                 'using default exposure time of 1000 s')
-        moon_up_factor = getattr(config, 'moon_up_factor', None)
-        if moon_up_factor:
-            for cond in ['DARK', 'GRAY', 'BRIGHT']:
-                self.TEXP_TOTAL[cond] *= getattr(moon_up_factor, cond)()
-        else:
-            # Temporary hardcoded exposure factors for moon-up observing.
-            self.TEXP_TOTAL['GRAY'] *= 1.1
-            self.TEXP_TOTAL['BRIGHT'] *= 1.33
 
         # Initialize model of exposure time dependence on seeing.
         self.seeing_coefs = np.array([12.95475751, -7.10892892, 1.21068726])
-        self.seeing_coefs /= np.sqrt(self.weather_factor(1.1, 1.0))
-        assert np.allclose(self.weather_factor(1.1, 1.0), 1.)
+        self.seeing_coefs /= np.sqrt(self.weather_factor(1.1, 1.0, 1.0))
+        assert np.allclose(self.weather_factor(1.1, 1.0, 1.0), 1.)
         # Initialize optional history tracking.
         self.save_history = save_history
         if save_history:
             self.history = dict(mjd=[], signal=[], background=[], snr2frac=[])
 
-    def weather_factor(self, seeing, transp):
+    def weather_factor(self, seeing, transp, sky_level):
         """Return the relative SNR2 accumulation rate for specified conditions.
 
         This is the inverse of the instantaneous exposure factor due to seeing and transparency.
@@ -344,8 +336,14 @@ class ExposureTimeCalculator(object):
             Atmospheric seeing in arcseconds.
         transp : float
             Atmospheric transparency in the range (0,1).
+        sky_level : float
+            sky_level relative to nominal
         """
-        return (transp * (self.seeing_coefs[0] + seeing * (self.seeing_coefs[1] + seeing * self.seeing_coefs[2]))) ** 2
+        fac = transp**2
+        fac *= (self.seeing_coefs[0] + self.seeing_coefs[1]*seeing +
+                self.seeing_coefs[2]*seeing**2)**2
+        fac /= sky_level
+        return fac
 
     def estimate_exposure(self, program, snr2frac, exposure_factor, nexp_completed=0):
         """Estimate exposure time(s).
@@ -455,7 +453,7 @@ class ExposureTimeCalculator(object):
         # Estimate SNR2 to integrate in the next exposure.
         self.snr2frac_target = snr2frac + (texp_remaining / nexp) / self.texp_total
         # Initialize signal and background rate factors.
-        self.srate0 = np.sqrt(self.weather_factor(seeing, transp))
+        self.srate0 = np.sqrt(self.weather_factor(seeing, transp, 1.0))
         self.brate0 = sky
         self.signal = 0.
         self.background = 0.
@@ -493,7 +491,7 @@ class ExposureTimeCalculator(object):
         """
         dt = mjd_now - self.mjd_last
         self.mjd_last = mjd_now
-        srate = np.sqrt(self.weather_factor(seeing, transp))
+        srate = np.sqrt(self.weather_factor(seeing, transp, 1.0))
         brate = sky
         self.signal += dt * srate / self.srate0
         #self.background += dt * (srate + brate) / (self.srate0 + self.brate0)

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -406,12 +406,16 @@ class Scheduler(object):
 
         weather_factor = ETC.weather_factor(seeing, transp, skylevel)
         esttime = (
-            self.nominal_exposure_time_sec[self.tile_sel]/86400*weather_factor)
+            self.nominal_exposure_time_sec[self.tile_sel]/86400 *
+            self.tiles.dust_factor[self.tile_sel] / weather_factor)
+        airmassnom = self.tiles.airmass(
+            self.LST - self.tiles.tileRA[self.tile_sel], self.tile_sel)
+        esttime *= desisurvey.etc.airmass_exposure_factor(airmassnom)
         esttime = np.clip(esttime, 0, self.maxtime.to(u.day).value)
 
         self.hourangle[:] = 0.
         self.hourangle[self.tile_sel] = (
-            self.LST + esttime/2/360 - self.tiles.tileRA[self.tile_sel])
+            self.LST + 360*esttime/2 - self.tiles.tileRA[self.tile_sel])
         # Calculate the airmass of each available tile.
         self.airmass[:] = self.max_airmass
         self.airmass[self.tile_sel] = self.tiles.airmass(

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -133,6 +133,10 @@ class Scheduler(object):
         self.tile_available = np.zeros(self.tiles.ntiles, bool)
         self.tile_planned = np.zeros(self.tiles.ntiles, bool)
         self.tile_priority = np.zeros(self.tiles.ntiles, float)
+        self.nominal_exposure_time_sec = (
+            desisurvey.tiles.get_nominal_program_times(self.tiles.tileprogram))
+        self.maxtime = config.maxtime()
+
         # Lookup avoidance cone angles.
         self.avoid_bodies = {}
         for body in config.avoid_bodies.keys:
@@ -374,6 +378,7 @@ class Scheduler(object):
             if verbose:
                 self.log.warning('No available tiles in requested program.')
             return None, None, None, None, None, program, mjd_program_end
+
         # Calculate the local apparent sidereal time in degrees.
         self.LST = self.LST0 + self.dLST * (mjd_now - self.MJD0)
         # Calculate the hour angle of each available tile in degrees.
@@ -393,6 +398,7 @@ class Scheduler(object):
             if verbose:
                 self.log.warning('No tiles left to observe after HA/airmass cut.')
             return None, None, None, None, None, program, mjd_program_end
+
         # Is the moon up?
         if mjd_now > self.night_ephem['moonrise'] and mjd_now < self.night_ephem['moonset']:
             moon_is_up = True
@@ -412,12 +418,14 @@ class Scheduler(object):
                 return None, None, None, None, None, program, mjd_program_end
         else:
             moon_is_up = False
+
         # Estimate exposure factors for all available tiles.
         self.exposure_factor[:] = 1e8
         self.exposure_factor[self.tile_sel] = self.tiles.dust_factor[self.tile_sel]
         self.exposure_factor[self.tile_sel] *= desisurvey.etc.airmass_exposure_factor(self.airmass[self.tile_sel])
         # Apply global weather factors that are the same for all tiles.
-        self.exposure_factor[self.tile_sel] /= ETC.weather_factor(seeing, transp)
+        self.exposure_factor[self.tile_sel] /= ETC.weather_factor(
+            seeing, transp, skylevel)
         if not np.any(self.tile_sel):
             return None, None, None, None, None, program, mjd_program_end
         # Calculate (the log of a) Gaussian multiplicative penalty for

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -379,26 +379,6 @@ class Scheduler(object):
                 self.log.warning('No available tiles in requested program.')
             return None, None, None, None, None, program, mjd_program_end
 
-        # Calculate the local apparent sidereal time in degrees.
-        self.LST = self.LST0 + self.dLST * (mjd_now - self.MJD0)
-        # Calculate the hour angle of each available tile in degrees.
-        #######################################################
-        ### should be offset to estimated exposure midpoint ###
-        #######################################################
-        self.hourangle[:] = 0.
-        self.hourangle[self.tile_sel] = self.LST - self.tiles.tileRA[self.tile_sel]
-        # Calculate the airmass of each available tile.
-        self.airmass[:] = self.max_airmass
-        self.airmass[self.tile_sel] = self.tiles.airmass(
-            self.hourangle[self.tile_sel], self.tile_sel)
-        self.tile_sel &= self.airmass < self.max_airmass
-        absha = np.abs(((self.hourangle + 180) % 360)-180)
-        self.tile_sel &= (absha < self.max_ha)
-        if not np.any(self.tile_sel):
-            if verbose:
-                self.log.warning('No tiles left to observe after HA/airmass cut.')
-            return None, None, None, None, None, program, mjd_program_end
-
         # Is the moon up?
         if mjd_now > self.night_ephem['moonrise'] and mjd_now < self.night_ephem['moonset']:
             moon_is_up = True
@@ -419,13 +399,37 @@ class Scheduler(object):
         else:
             moon_is_up = False
 
+
+        # Calculate the local apparent sidereal time in degrees.
+        self.LST = self.LST0 + self.dLST * (mjd_now - self.MJD0)
+        # Calculate the hour angle of each available tile in degrees.
+
+        weather_factor = ETC.weather_factor(seeing, transp, skylevel)
+        esttime = (
+            self.nominal_exposure_time_sec[self.tile_sel]/86400*weather_factor)
+        esttime = np.clip(esttime, 0, self.maxtime.to(u.day).value)
+
+        self.hourangle[:] = 0.
+        self.hourangle[self.tile_sel] = (
+            self.LST + esttime/2/360 - self.tiles.tileRA[self.tile_sel])
+        # Calculate the airmass of each available tile.
+        self.airmass[:] = self.max_airmass
+        self.airmass[self.tile_sel] = self.tiles.airmass(
+            self.hourangle[self.tile_sel], self.tile_sel)
+        self.tile_sel &= self.airmass < self.max_airmass
+        absha = np.abs(((self.hourangle + 180) % 360)-180)
+        self.tile_sel &= (absha < self.max_ha)
+        if not np.any(self.tile_sel):
+            if verbose:
+                self.log.warning('No tiles left to observe after HA/airmass cut.')
+            return None, None, None, None, None, program, mjd_program_end
+
         # Estimate exposure factors for all available tiles.
         self.exposure_factor[:] = 1e8
         self.exposure_factor[self.tile_sel] = self.tiles.dust_factor[self.tile_sel]
         self.exposure_factor[self.tile_sel] *= desisurvey.etc.airmass_exposure_factor(self.airmass[self.tile_sel])
         # Apply global weather factors that are the same for all tiles.
-        self.exposure_factor[self.tile_sel] /= ETC.weather_factor(
-            seeing, transp, skylevel)
+        self.exposure_factor[self.tile_sel] /= weather_factor
         if not np.any(self.tile_sel):
             return None, None, None, None, None, program, mjd_program_end
         # Calculate (the log of a) Gaussian multiplicative penalty for

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -156,15 +156,18 @@ def afternoon_plan(night=None, restore_etc_stats='most_recent',
                          'DESI_SPECTRA_DIR.')
 
     if sv:
-        if os.environ.get('DESI_COLLAB_PASSWORD', None) is not None:
-            pwstr = '--password ' + os.environ['DESI_COLLAB_PASSWORD'] + ' '
-        else:
-            print('Enter desi collaboration password to download status file.')
-            pwstr = '--ask-password '
         os.system('wget -q https://data.desi.lbl.gov/desi/survey/observations/'
-                  'SV1/sv1-exposures.fits ' + pwstr +
-                  '--user=desi -O ./sv1-exposures.fits')
-        offlinedepthfn = './sv1-exposures.fits'
+                  'SV1/sv1-exposures.fits -O ./sv1-exposures.new.fits')
+        filelen = os.stat('sv1-exposures.new.fits').st_size
+        if filelen > 0:
+            os.rename('sv1-exposures.new.fits', 'sv1-exposures.fits')
+            offlinedepthfn = './sv1-exposures.fits'
+        else:
+            log.warning('Updating sv1-exposures failed!')
+            if os.path.exists('./sv1-exposures.fits'):
+                offlinedepthfn = './sv1-exposures.fits'
+            else:
+                offlinedepthfn = None
     else:
         offlinedepthfn = None
 

--- a/py/desisurvey/test/test_etc.py
+++ b/py/desisurvey/test/test_etc.py
@@ -80,7 +80,7 @@ class TestExpCalc(unittest.TestCase):
             # faster in lower seeing, higher transparency, lower sky
             self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0), ETC.weather_factor(1.1, 1.0, 1.0))
             self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0), ETC.weather_factor(1.0, 0.9, 1.0))
-            self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0, ETC.weather_factor(1.0, 1.0, 1.1))
+            self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0), ETC.weather_factor(1.0, 1.0, 1.1))
             # Lookup the nominal DARK exposure time in days.
             config = desisurvey.config.Configuration()
             tnom = getattr(config.nominal_exposure_time, 'DARK')().to(u.day).value

--- a/py/desisurvey/test/test_etc.py
+++ b/py/desisurvey/test/test_etc.py
@@ -76,8 +76,11 @@ class TestExpCalc(unittest.TestCase):
         for save in False, True:
             ETC = ExposureTimeCalculator(save_history=save)
             # Check for sensible scaling with conditions.
-            self.assertGreater(ETC.weather_factor(1.0, 1.0), ETC.weather_factor(1.1, 1.0))
-            self.assertGreater(ETC.weather_factor(1.0, 1.0), ETC.weather_factor(1.0, 0.9))
+            # seeing, transparency, sky
+            # faster in lower seeing, higher transparency, lower sky
+            self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0), ETC.weather_factor(1.1, 1.0, 1.0))
+            self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0), ETC.weather_factor(1.0, 0.9, 1.0))
+            self.assertGreater(ETC.weather_factor(1.0, 1.0, 1.0, ETC.weather_factor(1.0, 1.0, 1.1))
             # Lookup the nominal DARK exposure time in days.
             config = desisurvey.config.Configuration()
             tnom = getattr(config.nominal_exposure_time, 'DARK')().to(u.day).value


### PR DESCRIPTION
This PR moves sky computations into the ETC in preparation for a more detailed sky model.  Corresponding changes are necessary to desihub/desisurvey in order to work with this.

The present version only passes the current exposure time scalings for DARK/GRAY/BRIGHT into the sky, so that the survey sims are unchanged, despite the nominal times no longer being scaled by moon up factors.

This PR also implements a change where scheduler.next_tile looks for tiles whose hour angles will match the optimizations at the midpoints of the observations, rather than the beginnings of the observations.  This will make a difference ~now for operations on the mountain.

This will break the surveysim tests, since this and the corresponding surveysim PRs depend on one another.  I can't remember how we solve that?