### PR TITLE
Add option removing the gray layer

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,9 @@ desisurvey change log
 0.15.1 (unreleased)
 -------------------
 
+* Optionally merge dark and gray layers.  Implement nopass strategy.
+  Move scheduler state to planner and start to change data model.
+  (PR `#130`)
 * Use sky levels in ETC.  Use EFFTIME rather than R_DEPTH, and harmonize
   MW extinction correction with EFFTIME.  (PR `#129`_)
 * Fix bug in transparency and ETC snr2 accumulation rate calculation
@@ -12,6 +15,7 @@ desisurvey change log
 
 .. _`#128`: https://github.com/desihub/desisurvey/pull/128
 .. _`#129`: https://github.com/desihub/desisurvey/pull/129
+.. _`#130`: https://github.com/desihub/desisurvey/pull/130
 
 0.15.0 (2021-02-15)
 -------------------

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -234,8 +234,6 @@ class NTS():
             print(e)
             raise ValueError('Error restoring scheduler & planner files; '
                              'has afternoon planning been performed?')
-        self.scheduler.update_tiles(self.planner.tile_available,
-                                    self.planner.tile_priority)
         self.scheduler.init_night(self.night, use_twilight=True)
         self.ETC = desisurvey.etc.ExposureTimeCalculator()
 

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -235,7 +235,7 @@ class NTS():
                              'has afternoon planning been performed?')
         self.scheduler.init_night(self.night, use_twilight=True)
         for queuedtile in self.queuedlist.queued:
-            self.scheduler.add_pending_tile(queuedtile)
+            self.scheduler.plan.add_pending_tile(queuedtile)
         self.ETC = desisurvey.etc.ExposureTimeCalculator()
 
     def next_tile(self, conditions=None, exposure=None, constraints=None,
@@ -355,7 +355,7 @@ class NTS():
             self.requestlog.logresponse(tile)
             return tile
 
-        self.scheduler.add_pending_tile(tileid)
+        self.scheduler.plan.add_pending_tile(tileid)
 
         if self.commissioning:
             self.log.info('Ignoring existing donefrac in SV1.')

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -224,8 +224,7 @@ class NTS():
             self.planner = desisurvey.plan.Planner(
                 self.rules,
                 restore='{}/desi-status-{}.fits'.format(fulldir, nts_dir))
-            self.scheduler = desisurvey.scheduler.Scheduler(
-                restore='{}/desi-status-{}.fits'.format(fulldir, nts_dir))
+            self.scheduler = desisurvey.scheduler.Scheduler(self.planner)
             self.queuedlist = QueuedList(
                 config.get_path('{}/queued-{}.dat'.format(fulldir, nts_dir)))
             self.requestlog = RequestLog(

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -234,6 +234,8 @@ class NTS():
             raise ValueError('Error restoring scheduler & planner files; '
                              'has afternoon planning been performed?')
         self.scheduler.init_night(self.night, use_twilight=True)
+        for queuedtile in self.queuedlist.queued:
+            self.scheduler.add_pending_tile(queuedtile)
         self.ETC = desisurvey.etc.ExposureTimeCalculator()
 
     def next_tile(self, conditions=None, exposure=None, constraints=None,
@@ -352,6 +354,8 @@ class NTS():
                     'req_efftime': 0., 'sbprof': 'PSF'}
             self.requestlog.logresponse(tile)
             return tile
+
+        self.scheduler.add_pending_tile(tileid)
 
         if self.commissioning:
             self.log.info('Ignoring existing donefrac in SV1.')

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -135,10 +135,13 @@ fiber_assignment_cadence: daily
 # goes from observation until adjacent overlapping tiles may be observed
 # -1 if overlapping tiles may immediately be observed
 # default to -1 for any passes not listed.
+# 0 if overlapping tiles should not be observed on same night, but may
+# be observed on following day, without waiting for a full fiberassign interval
+# 1 if you have to wait a full interval.
 fiber_assignment_delay:
-    GRAY: -1
-    DARK: 0
-    BRIGHT: -1
+    GRAY: 0
+    DARK: 7
+    BRIGHT: 0
 
 # Nominal tile radius for determining whether two tiles overlap.
 tile_radius: 1.63 deg
@@ -166,4 +169,4 @@ tiles_nogray: True
 # using environment variables.
 output_path: '{DESISURVEY_OUTPUT}'
 
-rules_file: rules.yaml
+rules_file: rules-depth.yaml

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -172,4 +172,4 @@ tiles_nogray: True
 # using environment variables.
 output_path: '{DESISURVEY_OUTPUT}'
 
-rules_file: rules-depth.yaml
+rules_file: rules.yaml

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -129,22 +129,16 @@ avoid_bodies:
 # Specify the cadence for updating fiber assignments. The choices are:
 # - monthly: perform updates at every full moon break.
 # - daily: perform updates as part of every afternoon plan.
-fiber_assignment_cadence: monthly
+fiber_assignment_cadence: daily
 
-# Specify the fiber-assignment ordering dependencies between passes.
-# For example, "P2: P0+P1 delay 1" means that a tile in pass 2
-# cannot be fiber assigned until all overlapping tiles in passes
-# 0 and 1 have been completed. A delay value of 1 indicates
-# that fiber assignment for pass 2 is delayed by 1 day / month
-# (depending on fiber_assignment_cadence) after all overlapping
-# tiles have been completed, to allow sufficient time to
-# analyze offline outputs and confirm targeting decisions.
-# Similarly, a delay of 0 indicates that fibers are assigned on
-# the first day / month after the covering tiles are completed.
-fiber_assignment_order:
-    P2: P1 delay 1
-    P3: P1+P2 delay 1
-    P4: P1+P2 delay 1
+# number of fiber_assignement_cadence units to wait before a tile
+# goes from observation until adjacent overlapping tiles may be observed
+# -1 if overlapping tiles may immediately be observed
+# default to -1 for any passes not listed.
+fiber_assignment_delay:
+    GRAY: -1
+    DARK: 0
+    BRIGHT: -1
 
 # Nominal tile radius for determining whether two tiles overlap.
 tile_radius: 1.63 deg

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -164,9 +164,12 @@ tile_radius: 1.63 deg
 #   an update to fiber_assignment_order, above.
 tiles_file: desi-tiles.fits
 
+# Merge dark and gray programs.
+tiles_nogray: True
+
 # Base path to pre-pended to all non-absolute paths used for reading and
 # writing files managed by this package. The pattern {...} will be expanded
 # using environment variables.
 output_path: '{DESISURVEY_OUTPUT}'
 
-rules_file: rules.yaml
+rules_file: rules-depth.yaml

--- a/py/desisurvey/data/rules-depth.yaml
+++ b/py/desisurvey/data/rules-depth.yaml
@@ -10,63 +10,43 @@
 NHI:
     # Expand upwards from DEC=18deg in all passes.
     cap: N
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     dec_min: 18
     dec_order: +0.2
     rules:
-        NHI(0): { START: 1.0 }
-        NHI(1): { START: 1.0 }
-        NHI(2): { START: 1.0 }
-        NHI(3): { START: 1.0 }
-        NHI(4): { START: 1.0 }
-        NHI(5): { START: 1.0 }
-        NHI(6): { START: 1.0 }
-        NHI(7): { START: 1.0 }
+        NHI(GRAY): { START: 1.0 }
+        NHI(DARK): { START: 1.0 }
+        NHI(BRIGHT): { START: 1.0 }
 
 NLO:
     # Expand downwards from DEC=18deg in all passes.
     cap: N
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     dec_max: 18
     dec_order: -0.2
     rules:
-        NLO(0): { START: 1.0 }
-        NLO(1): { START: 1.0 }
-        NLO(2): { START: 1.0 }
-        NLO(3): { START: 1.0 }
-        NLO(4): { START: 1.0 }
-        NLO(5): { START: 1.0 }
-        NLO(6): { START: 1.0 }
-        NLO(7): { START: 1.0 }
+        NLO(GRAY): { START: 1.0 }
+        NLO(DARK): { START: 1.0 }
+        NLO(BRIGHT): { START: 1.0 }
 
 SHI:
     # Expand upwards from DEC=2deg in all passes.
     cap: S
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     dec_min: 2
     dec_order: +0.2
     rules:
-        SHI(0): { START: 1.0 }
-        SHI(1): { START: 1.0 }
-        SHI(2): { START: 1.0 }
-        SHI(3): { START: 1.0 }
-        SHI(4): { START: 1.0 }
-        SHI(5): { START: 1.0 }
-        SHI(6): { START: 1.0 }
-        SHI(7): { START: 1.0 }
+        SHI(GRAY): { START: 1.0 }
+        SHI(DARK): { START: 1.0 }
+        SHI(BRIGHT): { START: 1.0 }
 
 SLO:
     # Expand upwards from DEC=2deg in all passes.
     cap: S
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     dec_max: 2
     dec_order: -0.2
     rules:
-        SLO(0): { START: 1.0 }
-        SLO(1): { START: 1.0 }
-        SLO(2): { START: 1.0 }
-        SLO(3): { START: 1.0 }
-        SLO(4): { START: 1.0 }
-        SLO(5): { START: 1.0 }
-        SLO(6): { START: 1.0 }
-        SLO(7): { START: 1.0 }
+        SLO(GRAY): { START: 1.0 }
+        SLO(DARK): { START: 1.0 }
+        SLO(BRIGHT): { START: 1.0 }

--- a/py/desisurvey/data/rules-depth.yaml
+++ b/py/desisurvey/data/rules-depth.yaml
@@ -14,7 +14,7 @@ NHI:
     dec_min: 18
     dec_order: +0.2
     rules:
-        NHI(0): { START: 1.0 }
+        NHI(0): { START: 0.95 }
         NHI(1): { START: 1.0 }
         NHI(2): { START: 1.0 }
         NHI(3): { START: 1.0 }
@@ -30,7 +30,7 @@ NLO:
     dec_max: 18
     dec_order: -0.2
     rules:
-        NLO(0): { START: 1.0 }
+        NLO(0): { START: 0.95 }
         NLO(1): { START: 1.0 }
         NLO(2): { START: 1.0 }
         NLO(3): { START: 1.0 }
@@ -46,7 +46,7 @@ SHI:
     dec_min: 2
     dec_order: +0.2
     rules:
-        SHI(0): { START: 1.0 }
+        SHI(0): { START: 0.95 }
         SHI(1): { START: 1.0 }
         SHI(2): { START: 1.0 }
         SHI(3): { START: 1.0 }
@@ -62,7 +62,7 @@ SLO:
     dec_max: 2
     dec_order: -0.2
     rules:
-        SLO(0): { START: 1.0 }
+        SLO(0): { START: 0.95 }
         SLO(1): { START: 1.0 }
         SLO(2): { START: 1.0 }
         SLO(3): { START: 1.0 }

--- a/py/desisurvey/data/rules-depth.yaml
+++ b/py/desisurvey/data/rules-depth.yaml
@@ -14,7 +14,7 @@ NHI:
     dec_min: 18
     dec_order: +0.2
     rules:
-        NHI(0): { START: 0.95 }
+        NHI(0): { START: 1.0 }
         NHI(1): { START: 1.0 }
         NHI(2): { START: 1.0 }
         NHI(3): { START: 1.0 }
@@ -30,7 +30,7 @@ NLO:
     dec_max: 18
     dec_order: -0.2
     rules:
-        NLO(0): { START: 0.95 }
+        NLO(0): { START: 1.0 }
         NLO(1): { START: 1.0 }
         NLO(2): { START: 1.0 }
         NLO(3): { START: 1.0 }
@@ -46,7 +46,7 @@ SHI:
     dec_min: 2
     dec_order: +0.2
     rules:
-        SHI(0): { START: 0.95 }
+        SHI(0): { START: 1.0 }
         SHI(1): { START: 1.0 }
         SHI(2): { START: 1.0 }
         SHI(3): { START: 1.0 }
@@ -62,7 +62,7 @@ SLO:
     dec_max: 2
     dec_order: -0.2
     rules:
-        SLO(0): { START: 0.95 }
+        SLO(0): { START: 1.0 }
         SLO(1): { START: 1.0 }
         SLO(2): { START: 1.0 }
         SLO(3): { START: 1.0 }

--- a/py/desisurvey/data/rules-layers.yaml
+++ b/py/desisurvey/data/rules-layers.yaml
@@ -8,23 +8,18 @@
 
 DARK:
     dec_order: +0.2
-    passes: 1,2,3,4
+    programs: DARK
     rules:
-        DARK(1): { START: 1.0 }
-        DARK(2): { DARK(1): 1.0 }
-        DARK(3): { DARK(2): 1.0 }
-        DARK(4): { DARK(3): 1.0 }
+        DARK(DARK): { START: 1.0 }
 
 GRAY:
     dec_order: +0.2
-    passes: 0
+    programs: GRAY
     rules:
-        GRAY(0): { START: 1.0 }
+        GRAY(GRAY): { START: 1.0 }
 
 BRIGHT:
     dec_order: +0.2
-    passes: 5,6,7
+    programs: BRIGHT
     rules:
-        BRIGHT(5): { START: 1.0 }
-        BRIGHT(6): { BRIGHT(5): 1.0 }
-        BRIGHT(7): { BRIGHT(6): 1.0 }
+        BRIGHT(BRIGHT): { START: 1.0 }

--- a/py/desisurvey/data/rules.yaml
+++ b/py/desisurvey/data/rules.yaml
@@ -3,104 +3,50 @@
 # and prioritized. See doc/rules.rst for an explanation for the format.
 #-------------------------------------------------------------------
 
-# 15 < DEC < 25 stripe in NGC. Our goal is to observe this strip in DARK-1,2
-# GRAY-0 and BRIGHT-5,6 in year-1, then observe DARK-3,4 and BRIGHT-7 in year-2,
-# resulting in full depth for all programs by the end of year-2.
+# 15 < DEC < 25 stripe in NGC. Our goal is to observe this strip in DARK, GRAY,
+# BRIGHT first, then rest of area.
 N10:
     cap: N
     dec_min: 15
     dec_max: 25
     dec_order: +0.2
-    passes: 0,3,4,7
+    programs: GRAY, DARK, BRIGHT
     rules:
-        N10(0): { START: 1.0 }
-        N10(3): { N10LO(1): 0.8, N10HI(1): 1.0 }
-        N10(4): { N10LO(1): 0.6, N10HI(1): 0.8, N10(3): 1.0 }
-        N10(7): { N10LO(5): 0.8, N10HI(5): 1.0 }
+        N10(GRAY): { START: 1.0 }
+        N10(DARK): { START: 1.0 }
+        N10(BRIGHT): { START: 1.0 }
 
-# Pass-2 tiles in N10 need to cover passes 3, 4 for fiber assignment.
-N10P2:
-    covers: N10(3)+N10(4)
-    dec_order: +0.2
-    passes: 2
-    rules:
-        N10P2(2): { START: 0.8, N10P1(1): 1.0 }
-
-# Pass-1 tiles in N10 need to cover passes 2, 3, 4 for fiber assignment.
-N10P1:
-    covers: N10P2(2)+N10(3)+N10(4)
-    dec_order: +0.2
-    passes: 1
-    rules:
-        N10P1(1): { START: 1.0 }
-
-# Pass-6 tiles in N10 need to cover pass 7 for fiber assignment.
-N10P6:
-    covers: N10(7)
-    dec_order: +0.2
-    passes: 6
-    rules:
-        N10P6(6): { START: 0.8, N10P5(5): 1.0 }
-
-# Pass-5 tiles in N10 need to cover pass 6 for fiber assignment.
-N10P5:
-    covers: N10P6(6)+N10(7)
-    dec_order: +0.2
-    passes: 5
-    rules:
-        N10P5(5): { START: 1.0 }
-
-# NGC below DEC=15.  Tiles with DEC < 15 already assigned in the covering
-# regions defined above will not be reassigned here.
 N10LO:
     cap: N
     dec_max: 20
     dec_order: -0.2
     max_orphans: 4
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     rules:
-        N10LO(0): { START: 0.6, N10(0): 1.0 }
-        N10LO(1): { START: 0.7, N10P2(2): 1.0 }
-        N10LO(2): { N10HI(1): 0.6, N10(4): 1.0 }
-        N10LO(3): { N10HI(2): 1.0 }
-        N10LO(4): { N10HI(2): 1.0 }
-        N10LO(5): { START: 0.6, N10P6(6): 1.0 }
-        N10LO(6): { N10HI(5): 0.6, N10(7): 1.0 }
-        N10LO(7): { N10HI(6): 1.0 }
+        N10LO(GRAY): { START: 0.5, N10(GRAY): 1.0 }
+        N10LO(DARK): { START: 0.5, N10(DARK): 1.0 }
+        N10LO(BRIGHT): { START: 0.5, N10(BRIGHT): 1.0 }
 
-# NGC above DEC=25.  Tiles with DEC > 25 already assigned in the covering
-# regions defined above will not be reassigned here.
 N10HI:
     cap: N
     dec_min: 20
     dec_order: +0.2
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     rules:
-        N10HI(0): { START: 0.4, N10(0): 0.8, N10LO(0): 1.0 }
-        N10HI(1): { START: 0.3, N10LO(1): 0.6, N10P2(2): 1.0 }
-        N10HI(2): { N10HI(1): 0.4, N10(4): 0.8, N10LO(2): 1.0 }
-        N10HI(3): { N10HI(2): 0.8, N10LO(3): 1.0 }
-        N10HI(4): { N10HI(2): 0.8, N10LO(4): 1.0 }
-        N10HI(5): { START: 0.4, N10P6(6): 0.8, N10LO(4): 1.0 }
-        N10HI(6): { N10(7): 0.8, N10LO(6): 1.0 }
-        N10HI(7): { N10HI(6): 0.8, N10LO(7): 1.0 }
+        N10HI(GRAY): { START: 0.3, N10(GRAY): 0.5, N10LO(GRAY): 1.0 }
+        N10HI(DARK): { START: 0.3, N10(DARK): 0.5, N10LO(DARK): 1.0 }
+        N10HI(BRIGHT): { START: 0.3, N10(BRIGHT): 0.5, N10LO(BRIGHT): 1.0 }
 
-# SGC below DEC=5
 SLO:
     cap: S
     dec_max: 5
     dec_order: -0.2
     max_orphans: 2
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     rules:
-        SLO(0): { START: 1.0 }
-        SLO(1): { START: 1.0 }
-        SLO(2): { START: 0.5, SLO(1): 1.0 }
-        SLO(3): { SLO(1): 0.5, SLO(2): 1.0 }
-        SLO(4): { SLO(2): 0.5, SLO(3): 1.0 }
-        SLO(5): { START: 1.0 }
-        SLO(6): { START: 0.5, SLO(5): 1.0 }
-        SLO(7): { SLO(5): 0.5, SLO(6): 1.0 }
+        SLO(GRAY): { START: 1.0 }
+        SLO(DARK): { START: 1.0 }
+        SLO(BRIGHT): { START: 1.0 }
 
 # SGC above DEC=5
 SHI:
@@ -108,13 +54,8 @@ SHI:
     dec_min: 5
     dec_order: +0.2
     max_orphans: 2
-    passes: 0,1,2,3,4,5,6,7
+    programs: GRAY, DARK, BRIGHT
     rules:
-        SHI(0): { START: 0.5, SLO(0): 1.0 }
-        SHI(1): { START: 0.5, SLO(1): 1.0 }
-        SHI(2): { SLO(1): 0.5, SLO(2): 1.0 }
-        SHI(3): { SLO(2): 0.5, SLO(3): 1.0 }
-        SHI(4): { SLO(3): 0.5, SLO(4): 1.0 }
-        SHI(5): { START: 0.5, SLO(5): 1.0 }
-        SHI(6): { SLO(5): 0.5, SLO(6): 1.0 }
-        SHI(7): { SLO(6): 0.5, SLO(7): 1.0 }
+        SHI(GRAY): { START: 0.5, SLO(GRAY): 1.0 }
+        SHI(DARK): { START: 0.5, SLO(DARK): 1.0 }
+        SHI(BRIGHT): { START: 0.5, SLO(BRIGHT): 1.0 }

--- a/py/desisurvey/ephem.py
+++ b/py/desisurvey/ephem.py
@@ -451,7 +451,7 @@ class Ephemerides(object):
         if include_twilight:
             start = night_ephem['brightdusk']
             stop = night_ephem['brightdawn']
-            BRIGHT = desisurvey.tiles.Tiles.PROGRAM_INDEX['BRIGHT']
+            BRIGHT = desisurvey.tiles.Tiles.CONDITIONS_INDEX['BRIGHT']
             if programs[0] != BRIGHT:
                 # Twilight adds a BRIGHT program at the start of the night.
                 programs = np.insert(programs, 0, BRIGHT)
@@ -467,7 +467,7 @@ class Ephemerides(object):
         changes = np.concatenate(([start], changes, [stop]))
         if not program_as_int:
             # Replace program indices with names.
-            programs = [desisurvey.tiles.Tiles.PROGRAMS[pidx] for pidx in programs]
+            programs = [desisurvey.tiles.Tiles.CONDITIONS[pidx] for pidx in programs]
         return programs, changes
 
     def get_program_hours(self, start_date=None, stop_date=None,
@@ -591,7 +591,7 @@ class Ephemerides(object):
                 raise ValueError('Expected weather array of length {}.'.format(num_nights))
         # Initialize LST histograms for each program.
         lst_bins = np.linspace(origin, origin + 360, nbins + 1)
-        lst_hist = np.zeros((len(desisurvey.tiles.Tiles.PROGRAMS), nbins))
+        lst_hist = np.zeros((len(desisurvey.tiles.Tiles.CONDITIONS), nbins))
         dlst = 360. / nbins
         # Loop over nights.
         for n in range(num_nights):
@@ -675,9 +675,9 @@ class Ephemerides(object):
         tuple or array
             Tuple (dark, gray, bright) of boolean arrays that tabulates the
             program at each input MJD or an array of small integer indices
-            into :attr:`desisurvey.tiles.Tiles.PROGRAMS`, with the special value
-            -1 indicating DAYTIME. All output arrays have the same shape as
-            the input ``mjd`` array.
+            into :attr:`desisurvey.tiles.Tiles.CONDITIONS`, with the special
+            value -1 indicating DAYTIME. All output arrays have the same shape
+            as the input ``mjd`` array.
         """
         # Get the night of the earliest time.
         mjd = np.asarray(mjd)
@@ -720,9 +720,9 @@ class Ephemerides(object):
         else:
             # Default value -1=DAYTIME.
             program = np.full(mjd.shape, -1, np.int16)
-            program[dark] = desisurvey.tiles.Tiles.PROGRAM_INDEX['DARK']
-            program[gray] = desisurvey.tiles.Tiles.PROGRAM_INDEX['GRAY']
-            program[bright] = desisurvey.tiles.Tiles.PROGRAM_INDEX['BRIGHT']
+            program[dark] = desisurvey.tiles.Tiles.CONDITION_INDEX['DARK']
+            program[gray] = desisurvey.tiles.Tiles.CONDITION_INDEX['GRAY']
+            program[bright] = desisurvey.tiles.Tiles.CONDITION_INDEX['BRIGHT']
             return program
 
     def is_full_moon(self, night, num_nights=None):

--- a/py/desisurvey/ephem.py
+++ b/py/desisurvey/ephem.py
@@ -451,7 +451,7 @@ class Ephemerides(object):
         if include_twilight:
             start = night_ephem['brightdusk']
             stop = night_ephem['brightdawn']
-            BRIGHT = desisurvey.tiles.Tiles.CONDITIONS_INDEX['BRIGHT']
+            BRIGHT = desisurvey.tiles.Tiles.CONDITION_INDEX['BRIGHT']
             if programs[0] != BRIGHT:
                 # Twilight adds a BRIGHT program at the start of the night.
                 programs = np.insert(programs, 0, BRIGHT)

--- a/py/desisurvey/etc.py
+++ b/py/desisurvey/etc.py
@@ -309,7 +309,7 @@ class ExposureTimeCalculator(object):
         self.TEXP_TOTAL = {}
         self.log = desiutil.log.get_logger()
         unknownprograms = []
-        for program in desisurvey.tiles.Tiles.PROGRAMS:
+        for program in desisurvey.tiles.get_tiles().programs:
             nomtime = getattr(config.nominal_exposure_time, program, None)
             if nomtime is None:
                 unknownprograms.append(program)

--- a/py/desisurvey/forecast.py
+++ b/py/desisurvey/forecast.py
@@ -91,10 +91,10 @@ class Forecast(object):
         self.cummulative_days = np.cumsum(available, axis=1) / 24.
         # Calculate program parameters.
         ntiles, tsched, openfrac, dust, airmass, nominal = [], [], [], [], [], []
-        for program in tiles.PROGRAMS:
+        for program in tiles.programs:
             tile_sel = tiles.program_mask[program]
             ntiles.append(np.count_nonzero(tile_sel))
-            progindx = tiles.PROGRAM_INDEX[program]
+            progindx = tiles.program_index[program]
             scheduled_sum = scheduled[progindx].sum()
             tsched.append(scheduled_sum)
             openfrac.append(available[progindx].sum() / scheduled_sum)
@@ -117,14 +117,14 @@ class Forecast(object):
         """Print a summary table of the forecast parameters.
         """
         # Find the longest key and calculate the row length.
-        nprog = len(self.tiles.PROGRAMS)
+        nprog = len(self.tiles.programs)
         maxlen = np.max([len(key) for key in self.df])
         rowlen = maxlen + (1 + width) * nprog
         # Build a format string for each row.
         header = ' ' * maxlen + ' {{:>{}s}}'.format(width) * nprog
         row = '{{:>{}s}}'.format(maxlen) + ' {{:{}.{}g}}'.format(width, prec) * nprog
         # Print the header.
-        print(header.format(*self.tiles.PROGRAMS))
+        print(header.format(*self.tiles.programs))
         print(separator * rowlen)
         # Print each row.
         for key, values in self.df.items():
@@ -136,9 +136,9 @@ class Forecast(object):
                       split={'DARK': 100, 'GRAY': 100, 'BRIGHT':  75},
                       dead ={'DARK':  20, 'GRAY': 100, 'BRIGHT':  10}):
         df = self.df
-        df['Setup overhead / tile (s)'] = np.array([setup[p] for p in self.tiles.PROGRAMS])
-        df['Cosmic split overhead / tile (s)'] = np.array([split[p] for p in self.tiles.PROGRAMS])
-        df['Operations overhead / tile (s)'] = np.array([dead[p] for p in self.tiles.PROGRAMS])
+        df['Setup overhead / tile (s)'] = np.array([setup[p] for p in self.tiles.programs])
+        df['Cosmic split overhead / tile (s)'] = np.array([split[p] for p in self.tiles.programs])
+        df['Operations overhead / tile (s)'] = np.array([dead[p] for p in self.tiles.programs])
         df['Average available / tile (s)'] = (
             df['Scheduled time (hr)'] * df['Dome open fraction'] /
             # Avoid division by zero for a program with no tiles.
@@ -152,8 +152,8 @@ class Forecast(object):
                        moon    = {'DARK': 1.00, 'GRAY': 1.10, 'BRIGHT': 1.33},
                        weather = {'DARK': 1.22, 'GRAY': 1.20, 'BRIGHT': 1.16}):
         df = self.df
-        df['Moon factor'] = np.array([moon[p] for p in self.tiles.PROGRAMS])
-        df['Weather factor'] = np.array([weather[p] for p in self.tiles.PROGRAMS])
+        df['Moon factor'] = np.array([moon[p] for p in self.tiles.programs])
+        df['Weather factor'] = np.array([weather[p] for p in self.tiles.programs])
         df['Average required / tile (s)'] = (
             df['Nominal exposure (s)'] *
             df['Dust factor'] *
@@ -170,8 +170,8 @@ class Forecast(object):
             df['Average available / tile (s)'] /
             df['Average required / tile (s)'] - 1)
         self.pass_progress = np.zeros((self.tiles.npasses, self.num_nights))
-        for program in self.tiles.PROGRAMS:
-            progidx = self.tiles.PROGRAM_INDEX[program]
+        for program in self.tiles.programs:
+            progidx = self.tiles.program_index[program]
             dtexp = (
                 df['Average required / tile (s)'] +
                 df['Setup overhead / tile (s)'] +

--- a/py/desisurvey/forecast.py
+++ b/py/desisurvey/forecast.py
@@ -169,7 +169,8 @@ class Forecast(object):
         df['Exposure time margin (%)'] = 100 * (
             df['Average available / tile (s)'] /
             df['Average required / tile (s)'] - 1)
-        self.pass_progress = np.zeros((self.tiles.npasses, self.num_nights))
+        self.program_progress = np.zeros((len(self.tiles.programs),
+                                          self.num_nights))
         for program in self.tiles.programs:
             progidx = self.tiles.program_index[program]
             dtexp = (
@@ -183,9 +184,7 @@ class Forecast(object):
             # Compute progress assuming tiles are observed in pass order,
             # separated by exactly dtexp.
             ntiles_observed = 0
-            for passnum in self.tiles.program_passes[program]:
-                passidx = self.tiles.pass_index[passnum]
-                ntiles = self.tiles.pass_ntiles[passnum]
-                self.pass_progress[passidx] = np.clip(
-                    progress - ntiles_observed, 0, ntiles)
-                ntiles_observed += ntiles
+            ntiles = np.sum(self.tiles.program_mask(program))
+            self.program_progress[programidx] = np.clip(
+                progress - ntiles_observed, 0, ntiles)
+            ntiles_observed += ntiles

--- a/py/desisurvey/forecast.py
+++ b/py/desisurvey/forecast.py
@@ -184,7 +184,7 @@ class Forecast(object):
             # Compute progress assuming tiles are observed in pass order,
             # separated by exactly dtexp.
             ntiles_observed = 0
-            ntiles = np.sum(self.tiles.program_mask(program))
-            self.program_progress[programidx] = np.clip(
+            ntiles = np.sum(self.tiles.program_mask[program])
+            self.program_progress[progidx] = np.clip(
                 progress - ntiles_observed, 0, ntiles)
             ntiles_observed += ntiles

--- a/py/desisurvey/optimize.py
+++ b/py/desisurvey/optimize.py
@@ -121,13 +121,13 @@ class Optimizer(object):
             idx = tiles.index(subset)
             # Check that all tiles in the subset are observable in these
             # conditions.
-            if not np.all(tiles.allowed_in_conditions[condition][subset]):
+            if not np.all(tiles.allowed_in_conditions(condition)[subset]):
                 raise ValueError('Subset contains non-{} tiles.'.format(condition))
             tile_sel = np.zeros(tiles.ntiles, bool)
             tile_sel[idx] = True
         else:
             # Use all tiles in the program by default.
-            tile_sel = tiles.allowed_in_conditions[condition]
+            tile_sel = tiles.allowed_in_conditions(condition)
 
         # Get nominal exposure time for this program,
         # converted to LST equivalent in degrees.

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -176,14 +176,12 @@ class Planner(object):
                 self.tile_countdown = self.tiles.fiberassign_delay.copy()
                 self.tile_covered[ind] = t['COVERED'].data[mask].copy()
                 self.tile_countdown[ind] = t['COUNTDOWN'].data[mask].copy()
-            self.snr2frac = np.zeros(self.tiles.ntiles, 'i4')
             self.tile_available = np.zeros(self.tiles.ntiles, bool)
             self.tile_priority = np.zeros(self.tiles.ntiles, 'f4')
             self.designha = np.zeros(self.tiles.ntiles, 'f4')
             self.designhacond = dict()
             self.donefrac = np.zeros(self.tiles.ntiles, 'f4')
             self.lastexpid = np.zeros(self.tiles.ntiles, 'i4')
-            self.snr2frac = t['DONEFRAC'].data[mask].copy()
             self.tile_available[ind] = t['AVAILABLE'].data[mask].copy()
             self.tile_priority[ind] = t['PRIORITY'].data[mask].copy()
             self.donefrac[ind] = t['DONEFRAC'].data[mask].copy()
@@ -197,7 +195,6 @@ class Planner(object):
                 np.count_nonzero(self.tile_available), self.tiles.ntiles, fullname))
         else:
             # Initialize the plan for a a new survey.
-            self.snr2frac = np.zeros(self.tiles.ntiles, bool)
             self.tile_available = np.zeros(self.tiles.ntiles, bool)
             self.donefrac = np.zeros(self.tiles.ntiles, 'f4')
             self.lastexpid = np.zeros(self.tiles.ntiles, 'i4')

--- a/py/desisurvey/rules.py
+++ b/py/desisurvey/rules.py
@@ -75,8 +75,8 @@ class Rules(object):
         NGC = (tiles.tileRA > 75.0) & (tiles.tileRA < 300.0)
         SGC = ~NGC
 
-        # Initialize regexp for parsing "GROUP_NAME(PASS)"
-        parser = re.compile(r'([^\(]+)\(([0-99]+)\)$')
+        # Initialize regexp for parsing "GROUP_NAME(PROGRAM)"
+        parser = re.compile('([^\(]+)\(([^\(]+)\)$')
 
         # Get the full path of the YAML file to read.
         if os.path.isabs(file_name):
@@ -113,49 +113,31 @@ class Rules(object):
             if dec_max is not None:
                 group_sel[tiles.tileDEC >= float(dec_max)] = False
             max_orphans = node.get('max_orphans') or 0
-            covers = node.get('covers')
-            if covers is not None:
-                # Build the set of all tiles that must be covered.
-                under = np.zeros(tiles.ntiles, bool)
-                for name in covers.split('+'):
-                    try:
-                        group_id = group_names.index(name) + 1
-                    except ValueError:
-                        raise RuntimeError('Invalid covers target: {0}.'
-                                           .format(name))
-                    under |= (group_ids == group_id)
 
             # Parse required "passes" attribute.
-            passes = node.get('passes')
-            if passes is None:
+            programs = node.get('programs')
+            if programs is None:
                 raise RuntimeError(
-                    'Missing required passes for {0}.'.format(group_name))
-            passes = [int(p) for p in str(passes).split(',')]
-            for p in tiles.passes:
-                if p not in passes:
-                    group_sel[tiles.passnum == p] = False
+                    'Missing required programs for {0}.'.format(group_name))
+            programs = [p.strip() for p in str(programs).split(',')]
+            for p in tiles.PROGRAMS:
+                if p not in programs:
+                    group_sel[tiles.tileprogram == p] = False
 
-            # Create GROUP(PASS) subgroup combinations.
+            # Create GROUP(PROGRAM) subgroup combinations.
             final_group_sel = np.zeros(tiles.ntiles, bool)
-            for p in passes:
-                pass_name = '{0}({1:d})'.format(group_name, p)
-                group_names.append(pass_name)
+            for p in programs:
+                program_name = '{0}({1})'.format(group_name, p)
+                group_names.append(program_name)
                 group_id = len(group_names)
-                pass_sel = group_sel & (tiles.passnum == p)
-                if covers is not None:
-                    # Limit to tiles covering at least one tile in "under".
-                    matrix = desisurvey.utils.separation_matrix(
-                        tiles.tileRA[pass_sel], tiles.tileDEC[pass_sel], tiles.tileRA[under], tiles.tileDEC[under],
-                        2 * tile_radius)
-                    overlapping = np.any(matrix, axis=1)
-                    pass_sel[pass_sel] &= overlapping
+                program_sel = group_sel & (tiles.tileprogram == p)
                 # Remove any tiles in this pass that have already been assigned
                 # to a previously defined subgroup.
-                pass_sel[pass_sel] &= ~(group_ids[pass_sel] != 0)
-                final_group_sel |= pass_sel
-                group_ids[pass_sel] = group_id
-                group_rules[pass_name] = {'START': 0.0}
-                group_max_orphans[pass_name] = max_orphans
+                program_sel[program_sel] &= ~(group_ids[program_sel] != 0)
+                final_group_sel |= program_sel
+                group_ids[program_sel] = group_id
+                group_rules[program_name] = {'START': 0.0}
+                group_max_orphans[program_name] = max_orphans
 
             # Some tiles may be dropped by covering requirements in this
             # or previous groups.
@@ -207,10 +189,10 @@ class Rules(object):
         # Check that all tiles are assigned to exactly one group.
         if np.any(group_ids == 0):
             orphans = (group_ids == 0)
-            passes = ','.join([str(s) for s in np.unique(tiles.passnum[orphans])])
+            programs = ','.join([str(s) for s in np.unique(tiles.tileprogram[orphans])])
             raise RuntimeError(
                 '{0} tiles in passes {1} not assigned to any group.'
-                .format(np.count_nonzero(orphans), passes))
+                .format(np.count_nonzero(orphans), programs))
 
         # Check that all rule triggers are valid subgroup names.
         for name in group_names:

--- a/py/desisurvey/rules.py
+++ b/py/desisurvey/rules.py
@@ -190,8 +190,9 @@ class Rules(object):
         if np.any(group_ids == 0):
             orphans = (group_ids == 0)
             programs = ','.join([str(s) for s in np.unique(tiles.tileprogram[orphans])])
-            raise RuntimeError(
-                '{0} tiles in passes {1} not assigned to any group.'
+            self.log.warning(
+                '{0} tiles in passes {1} not assigned to any group.  These '
+                'tiles will be given zero priority. '
                 .format(np.count_nonzero(orphans), programs))
 
         # Check that all rule triggers are valid subgroup names.

--- a/py/desisurvey/rules.py
+++ b/py/desisurvey/rules.py
@@ -120,7 +120,7 @@ class Rules(object):
                 raise RuntimeError(
                     'Missing required programs for {0}.'.format(group_name))
             programs = [p.strip() for p in str(programs).split(',')]
-            for p in tiles.PROGRAMS:
+            for p in tiles.programs:
                 if p not in programs:
                     group_sel[tiles.tileprogram == p] = False
 
@@ -222,13 +222,17 @@ class Rules(object):
         array
             Array of per-tile observing priorities.
         """
+
+        nogray = desisurvey.tiles.get_tiles().nogray
+
         # First pass through groups to check trigger conditions.
         triggered = {'START': True}
         for i, name in enumerate(self.group_names):
             gid = i+1
             group_sel = self.group_ids == gid
             if not np.any(group_sel) and not self.commissioning:
-                self.log.error('No tiles covered by rule {}'.format(name))
+                if not nogray or '(GRAY)' not in name:
+                    self.log.error('No tiles covered by rule {}'.format(name))
             ngroup = np.count_nonzero(group_sel)
             completed = donefrac > self.min_snr2_fraction
             ndone = np.count_nonzero(completed[group_sel])

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -385,6 +385,8 @@ class Scheduler(object):
         if donefrac >= self.min_snr2frac:
             if self.ignore_completed_priority <= 0:
                 self.in_night_pool[idx] = False
+            else:
+                self.plan.tile_priority[idx] = self.ignore_completed_priority
             self.completed[idx] = True
             progidx = self.tiles.program_index[self.tiles.tileprogram[idx]]
             self.completed_by_program[progidx] += 1

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -365,7 +365,7 @@ class Scheduler(object):
                 self.plan.donefrac[idx], self.exposure_factor[idx],
                 self.airmass[idx], program, mjd_program_end)
 
-    def update_snr(self, tileID, donefrac, lastexpid):
+    def update_snr(self, tileID, donefrac):
         """Update SNR for one tile.
 
         A tile whose update ``donefrac`` exceeds the ``min_snr2frac``
@@ -381,7 +381,7 @@ class Scheduler(object):
             all previous exposures.
         """
         idx = self.tiles.index(tileID)
-        self.plan.set_donefrac([tileID], [donefrac], [lastexpid])
+        self.plan.set_donefrac([tileID], [donefrac])
         if donefrac >= self.min_snr2frac:
             if self.ignore_completed_priority <= 0:
                 self.in_night_pool[idx] = False

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -52,7 +52,7 @@ class Scheduler(object):
         :func:`desisurvey.plan.load_design_hourangle` when None,
         when not restoring.
     """
-    def __init__(self, restore=None, design_hourangle=None):
+    def __init__(self, plan):
         self.log = desiutil.log.get_logger()
         # Load our configuration.
         config = desisurvey.config.Configuration()
@@ -61,6 +61,12 @@ class Scheduler(object):
         if not isinstance(ignore_completed_priority, int):
             ignore_completed_priority = ignore_completed_priority()
         self.ignore_completed_priority = ignore_completed_priority
+
+        nogray = getattr(config, 'tiles_nogray', False)
+        if not isinstance(nogray, bool):
+            nogray = nogray()
+        self.nogray = nogray
+
         self.min_snr2frac = config.min_snr2_fraction()
         GRAY = desisurvey.config.Configuration().programs.GRAY
         self.max_prod = GRAY.max_moon_illumination_altitude_product().to(u.deg).value
@@ -71,52 +77,16 @@ class Scheduler(object):
         # Load static tile info.
         self.tiles = desisurvey.tiles.get_tiles()
         ntiles = self.tiles.ntiles
-        # Initialize snr2frac, which is our only internal state.
-        if restore is not None:
-            # Restore the snr2frac array for a survey in progress.
-            fullname = config.get_path(restore)
-            if not os.path.exists(fullname):
-                raise RuntimeError('Cannot restore scheduler from non-existent "{}".'.format(fullname))
-            t = astropy.table.Table.read(fullname, hdu='STATUS')
-            ind, mask = self.tiles.index(t['TILEID'], return_mask=True)
-            ind = ind[mask]
-            self.snr2frac = np.zeros(ntiles, 'f4')
-            self.lastexpid = np.zeros(ntiles, 'i4')
-            self.design_hourangle = np.zeros(ntiles, 'f4')
-            self.design_hourangle_cond = np.zeros(ntiles, '3f4')
-            self.snr2frac[ind] = t['DONEFRAC'][mask].copy()
-            self.lastexpid[ind] = t['LASTEXPID'][mask].copy()
-            self.design_hourangle[ind] = t['DESIGNHA'][mask].copy()
-            self.design_hourangle_cond[ind] = t['DESIGNHACOND'][mask].copy()
-            self.log.debug('Restored scheduler snapshot from "{}".'.format(fullname))
-        else:
-            # Initialize for a new survey.
-            self.snr2frac = np.zeros(ntiles, float)
-            self.lastexpid = np.zeros(ntiles, float)
-            self.design_hourangle = desisurvey.plan.load_design_hourangle()
-            if self.design_hourangle.shape[0] != self.tiles.ntiles:
-                raise ValueError('design_hourangle has the wrong shape!')
-            self.design_hourangle_cond = np.array([
-                desisurvey.plan.load_design_hourangle(condition=cond)
-                for cond in ['DARK', 'GRAY', 'BRIGHT']]).T
-            if self.design_hourangle.shape[0] != self.tiles.ntiles:
-                raise ValueError('design_hourangle has the wrong shape!')
+        self.plan = plan
 
         # Initialize arrays derived from snr2frac.
         # Note that indexing of completed_by_pass uses tiles.pass_index, which is not necessarily
         # the same as range(tiles.npasses).
-        self.completed = (self.snr2frac >= self.min_snr2frac)
+        self.completed = (self.plan.snr2frac >= self.min_snr2frac)
         self.completed_by_pass = np.zeros(self.tiles.npasses, np.int32)
         for passnum in self.tiles.passes:
             idx = self.tiles.pass_index[passnum]
             self.completed_by_pass[idx] = np.count_nonzero(self.completed[self.tiles.passnum == passnum])
-
-        # Check hourangles.
-        if design_hourangle is not None:
-            self.design_hourangle = design_hourangle
-        if self.design_hourangle.shape != (self.tiles.ntiles,):
-            raise ValueError('Array design_hourangle has wrong shape.')
-
 
         # Allocate memory for internal arrays.
         self.exposure_factor = np.zeros(ntiles)
@@ -128,11 +98,10 @@ class Scheduler(object):
         self.night = None
         # Load the ephemerides to use.
         self.ephem = desisurvey.ephem.get_ephem()
-        # Initialize tile availability and priority.
-        # No tiles will be scheduled until these are updated using update_tiles().
-        self.tile_available = np.zeros(self.tiles.ntiles, bool)
-        self.tile_planned = np.zeros(self.tiles.ntiles, bool)
-        self.tile_priority = np.zeros(self.tiles.ntiles, float)
+
+        with np.errstate(divide='ignore'):
+            self.log_priority = np.log(self.plan.tile_priority)
+
         self.nominal_exposure_time_sec = (
             desisurvey.tiles.get_nominal_program_times(self.tiles.tileprogram))
         self.maxtime = config.maxtime()
@@ -141,57 +110,6 @@ class Scheduler(object):
         self.avoid_bodies = {}
         for body in config.avoid_bodies.keys:
             self.avoid_bodies[body] = getattr(config.avoid_bodies, body)().to(u.deg).value
-
-    def update_tiles(self, tile_available, tile_priority):
-        """Update tile availability and priority.
-
-        A valid update must have some tiles available with priority > 0.
-        Once a tile has been "planned", i.e., assigned priority > 0, it can
-        not be later un-planned, i.e., assigned zero priority.
-
-        Parameters
-        ----------
-        tile_available : array
-            1D array of booleans to indicate which tiles have had fibers assigned
-            and so are available to schedule.
-        tile_priority : array
-            1D array of per-tile priority values >= 0 used to implement survey strategy.
-
-        Returns
-        -------
-        tuple
-            Tuple (new_available, new_planned) of 1D arrays of tile indices that
-            identify any tiles are newly available or "planned" (assigned priority > 0).
-        """
-        new_available = tile_available & ~self.tile_available
-        new_unavailable = ~tile_available & self.tile_available
-        if np.any(new_unavailable):
-            raise RuntimeError('Some previously available tiles now unavailable.')
-        self.tile_available[new_available] = True
-
-        assert np.all(self.tile_priority >= 0)
-        if np.any(tile_priority < 0):
-            raise ValueError('All tile priorities must be >= 0.')
-        tile_planned = tile_priority > 0
-        new_planned = tile_planned & ~self.tile_planned
-        new_unplanned = ~tile_planned & self.tile_planned
-        if np.any(new_unplanned):
-            raise RuntimeError('Some previously planned tiles now have zero priority.')
-        self.tile_planned[new_planned] = True
-        # Tile priorities can change after they become > 0, so copy all planned priorities,
-        # not just the newly planned priorities.
-        self.tile_priority[self.tile_planned] = tile_priority[self.tile_planned]
-        # Precompute log(priority) since that is what we use for scheduling.
-        # Ignore harmless warnings about log(0) = -inf.
-        with np.errstate(divide='ignore'):
-            self.log_priority = np.log(self.tile_priority)
-
-        if not np.any(self.tile_available & self.tile_planned):
-            raise ValueError('No available tiles with priority > 0 to schedule.')
-        new_available, new_planned = np.where(new_available)[0], np.where(new_planned)[0]
-        self.log.debug('{} new available tiles, {} new planned tiles.'.format(
-            len(new_available), len(new_planned)))
-        return new_available, new_planned
 
     def init_night(self, night, use_twilight=False):
         """Initialize scheduling for the specified night.
@@ -222,7 +140,7 @@ class Scheduler(object):
             Generate verbose logging output when True.
         """
         self.log.debug('Initializing scheduler for {}'.format(night))
-        if self.tile_available is None or self.tile_priority is None:
+        if self.plan.tile_available is None or self.plan.tile_priority is None:
             raise RuntimeError('Must call update_tiles() before init_night().')
         self.night = night
         self.night_ephem = self.ephem.get_night(night)
@@ -237,11 +155,9 @@ class Scheduler(object):
         self.LST0, LST1 = [
             self.night_ephem['brightdusk_LST'], self.night_ephem['brightdawn_LST']]
         self.dLST = (LST1 - self.LST0) / (MJD1 - self.MJD0)
-        # Initialize tracking of the program through the night.
-        # Remember the last tile observed this night.
-        self.last_idx = None
+
         # Initialize the pool of tiles that could be observed this night.
-        self.in_night_pool[:] = self.tile_planned & self.tile_available
+        self.in_night_pool[:] = (self.plan.tile_priority > 0) & self.plan.tile_available
         if self.ignore_completed_priority <= 0:
              self.in_night_pool &= ~self.completed
         # Check if any tiles cannot be observed because they are too close to a planet this night.
@@ -284,7 +200,12 @@ class Scheduler(object):
         program = self.night_programs[idx]
         # How much time remaining in this program?
         mjd_program_end = self.night_changes[idx + 1]
-        nommidpt = mjd_now + (ETC.TEXP_TOTAL[program]/2)
+        # switch to next program if less than 5 min left in this program.
+        # to do better here we need to think about the nominal exposure length
+        # in each program.
+        # and we're going to redo this thinking shortly when we switch to
+        # speed based program selection.
+        nommidpt = mjd_now + 300/86400
         if (nommidpt > mjd_program_end) & (idx != len(self.night_programs)-1):
             idx += 1
             program = self.night_programs[idx]
@@ -364,7 +285,7 @@ class Scheduler(object):
             # Which program are we in?
             program, mjd_program_end = self.select_program(
                 mjd_now, ETC, verbose=verbose)
-            self.tile_sel &= self.tiles.allowed_in_conditions[program]
+            self.tile_sel &= self.tiles.allowed_in_conditions(program)
             if verbose:
                 self.log.info(
                     'Selecting a tile observable in {} conditions.'.format(
@@ -438,7 +359,11 @@ class Scheduler(object):
             return None, None, None, None, None, program, mjd_program_end
         # Calculate (the log of a) Gaussian multiplicative penalty for
         # observing tiles away from their design hour angle.
-        dHA = self.hourangle[self.tile_sel] - self.design_hourangle_cond[self.tile_sel, self.tiles.PROGRAM_INDEX[program]]
+        cond = program
+        if self.nogray:
+            cond = 'DARK' if cond == 'GRAY' else cond
+        dHA = (self.hourangle[self.tile_sel] -
+               self.plan.designhacond[cond][self.tile_sel])
         dHA[dHA >= 180.] -= 360
         dHA[dHA < -180] += 360
         assert np.all((dHA >= -180) & (dHA < 180))
@@ -453,7 +378,7 @@ class Scheduler(object):
 
         # Return info about the selected tile and scheduled program.
         return (self.tiles.tileID[idx], self.tiles.passnum[idx],
-                self.snr2frac[idx], self.exposure_factor[idx],
+                self.plan.snr2frac[idx], self.exposure_factor[idx],
                 self.airmass[idx], program, mjd_program_end)
 
     def update_snr(self, tileID, snr2frac, lastexpid):
@@ -471,18 +396,14 @@ class Scheduler(object):
             New value of the fractional SNR2 accumulated for this tile, including
             all previous exposures.
         """
-        idx = self.tiles.index(tileID)
-        self.snr2frac[idx] = snr2frac
-        self.lastexpid[idx] = lastexpid
-        if self.snr2frac[idx] >= self.min_snr2frac:
+        self.plan.set_donefrac([tileID], [snr2frac], [lastexpid])
+        if snr2frac >= self.min_snr2frac:
+            idx = self.tiles.index(tileID)
             if self.ignore_completed_priority <= 0:
                 self.in_night_pool[idx] = False
             self.completed[idx] = True
             passidx = self.tiles.pass_index[self.tiles.passnum[idx]]
             self.completed_by_pass[passidx] += 1
-
-        # Remember the last tile observed this night.
-        self.last_idx = idx
 
     def survey_completed(self):
         """Test if all tiles have been completed.

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -211,6 +211,13 @@ def afternoon_plan(night=None, restore_etc_stats='most_recent',
                  donefraccond['NNIGHT_NEEDED_'+cond][md])
             condmask = desisurvey.tiles.Tiles.OBSCONDITIONS[cond]
             newobsconditions[mt[m]] &= ~condmask
+        tob = desisurvey.tiles.get_tiles()
+        if tob.nogray:
+            graycond = desisurvey.tiles.Tiles.OBSCONDITIONS['GRAY']
+            darkcond = desisurvey.tiles.Tiles.OBSCONDITIONS['DARK']
+            newobsconditions &= ~graycond
+            newobsconditions |= graycond * ((darkcond & newobsconditions) != 0)
+
         ignore_completed_priority = getattr(config,
                                             'ignore_completed_priority', -1)
         if not isinstance(ignore_completed_priority, int):

--- a/py/desisurvey/scripts/afternoon_plan.py
+++ b/py/desisurvey/scripts/afternoon_plan.py
@@ -177,8 +177,7 @@ def afternoon_plan(night=None, restore_etc_stats='most_recent',
     collect_etc.write_tile_exp(tiles, exps, os.path.join(
         directory, 'etc-stats-{}.fits'.format(subdir)))
 
-    planner.set_donefrac(tiles['TILEID'], tiles['DONEFRAC_ETC'],
-                         tiles['LASTEXPID_ETC'])
+    planner.set_donefrac(tiles['TILEID'], tiles['DONEFRAC_ETC'])
 
     if sv:
         # overwrite donefracs
@@ -193,11 +192,9 @@ def afternoon_plan(night=None, restore_etc_stats='most_recent',
             nobserved += donefraccond['NNIGHT_'+cond]
         _, md, mt = np.intersect1d(donefraccond['TILEID'],
                                    tiles['TILEID'], return_indices=True)
-        lastexp = np.zeros(len(donefraccond), dtype='i4')-1
-        lastexp[md] = tiles['LASTEXPID_ETC'][mt]
         nneeded = nneeded + (nneeded == 0)
         planner.set_donefrac(donefraccond['TILEID'],
-                             nobserved / nneeded, lastexp)
+                             nobserved / nneeded)
         hdulist = fits.open(newtilefn)
         hdu = hdulist['TILES']
         tilefiledat = hdu.data

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -263,9 +263,9 @@ def get_conditions(mjd):
                                      night['changes'][night['changes'] != 0],
                                      [night['dawn'], night['brightdawn']]])
         nightprograms = np.concatenate([
-            [tiles.PROGRAM_INDEX['BRIGHT']],
+            [tiles.CONDITION_INDEX['BRIGHT']],
             night['programs'][night['programs'] != -1],
-            [tiles.PROGRAM_INDEX['BRIGHT']]])
+            [tiles.CONDITION_INDEX['BRIGHT']]])
         if len(nightprograms) != len(nighttimes)-1:
             raise ValueError('number of program changes does not match '
                              'number of programs!')
@@ -279,7 +279,7 @@ def get_conditions(mjd):
     # this program index is ~backwards from OBSCONDITIONS.
     newout = out.copy()
     for condition in tiles.OBSCONDITIONS:
-        m = out == tiles.PROGRAM_INDEX[condition]
+        m = out == tiles.CONDITION_INDEX[condition]
         newout[m] = tiles.OBSCONDITIONS[condition]
     return newout
 

--- a/py/desisurvey/scripts/run_plan.py
+++ b/py/desisurvey/scripts/run_plan.py
@@ -47,9 +47,10 @@ def run_plan(nts_dir=None, verbose=False):
     print(nts.scheduler.night)
     for name, tt in zip(night_labels[s], night_times[s]):
         print('%11s %s' % (name, mjd_to_azstr(tt)))
+    dgbstr = 'd/g/b' if not nts.scheduler.tiles.nogray else 'd/b'
 
-    print('local   lst   cond  tile    ra   dec    program fac  tot  split '
-          'd/g/b')
+    print('local   lst   cond  tile    ra   dec    program fac  tot  split ' +
+          dgbstr)
     while t0 < nts.scheduler.night_ephem['brightdawn']:
         expdict = dict(mjd=t0, previoustiles=previoustiles)
         res = nts.next_tile(exposure=expdict, speculative=True)
@@ -70,13 +71,18 @@ def run_plan(nts_dir=None, verbose=False):
                       nsofar['NNIGHT_BRIGHT']]
         else:
             nsofar = [0, 0, 0]
+        if not nts.scheduler.tiles.nogray:
+            dgbstr = '%3.1f/%3.1f/%3.1f' % nsofar
+        else:
+            nsofar = (nsofar[0], nsofar[2])
+            dgbstr = '%3.1f/%3.1f' % nsofar
         print(
             ('%s %5.1f %6s %d %5.1f %5.1f %10s %3.1f '
-             '%4d %6s %3.1f/%3.1f/%3.1f') % (
+             '%4d %6s %s') % (
             mjd_to_azstr(t0), lst, res['conditions'],
             res['fiberassign'], ra, dec, res['program'],
             res['exposure_factor'], res['esttime'].astype('i4'),
-            ('%dx%d' % (res['count'], res['exptime'])), *nsofar))
+                 ('%dx%d' % (res['count'], res['exptime'])), dgbstr))
         t0 += (res['exptime']+180)*res['count']/60/60/24
 
 

--- a/py/desisurvey/scripts/surveyinit.py
+++ b/py/desisurvey/scripts/surveyinit.py
@@ -166,17 +166,14 @@ def calculate_initial_plan(args):
         include_twilight=args.include_twilight)
     lst_centers = 0.5*(lst_bins[:-1]+lst_bins[1:])
 
-    no_gray_tiles = getattr(config, 'tiles_nogray', False)
-    if not isinstance(no_gray_tiles, bool):
-        no_gray_tiles = no_gray_tiles()
-    if no_gray_tiles:
+    if tiles.nogray:
         grayordark = tiles.OBSCONDITIONS['DARK'] | tiles.OBSCONDITIONS['GRAY']
         mgrayordark = (tiles.tileobsconditions & grayordark) != 0
         m = (tiles.tileobsconditions[mgrayordark] & grayordark) != grayordark
         if np.any(m):
             log.warning((
                 '{} tiles observable in either dark or gray, but '
-                'not both.  no_gray_tiles is True, so gray and '
+                'not both.  tiles.nogray is True, so gray and '
                 'dark LST are being optimized together.  For LST planning '
                 'purposes, all gray/dark tiles are assigned to a common '
                 'bucket.').format(np.sum(m)))
@@ -184,11 +181,9 @@ def calculate_initial_plan(args):
         new_lst_hist[0, :] = lst_hist[0, :] + lst_hist[1, :]
         new_lst_hist[1, :] = lst_hist[2, :]
         lst_hist = new_lst_hist[0:2, :].copy()
-        m = (tiles.tileobsconditions & grayordark) != 0
-        tiles.tileobsconditions[m] = grayordark
 
     # Initialize the output results table.
-    if no_gray_tiles:
+    if tiles.nogray:
         conditions = ['DARK', 'BRIGHT']
     else:
         conditions = ['DARK', 'GRAY', 'BRIGHT']
@@ -206,7 +201,7 @@ def calculate_initial_plan(args):
         GRAY=args.gray_stretch,
         BRIGHT=args.bright_stretch)
 
-    if no_gray_tiles:
+    if tiles.nogray:
         stretches.pop('GRAY')
 
     tile_is_assignable = np.zeros(tiles.ntiles, dtype='bool')

--- a/py/desisurvey/scripts/surveyinit.py
+++ b/py/desisurvey/scripts/surveyinit.py
@@ -101,9 +101,6 @@ def parse(options=None):
     parser.add_argument(
         '--include-weather', default=True, type=bool,
         help='Use past weather to discount available LST when planning.')
-    parser.add_argument(
-        '--separate-gray-dark', default=False, type=bool,
-        help='Allow separate gray/dark optimization.')
 
     if options is None:
         args = parser.parse_args()
@@ -160,7 +157,6 @@ def calculate_initial_plan(args):
     # Calculate the distribution of available LST in each program
     # during the nominal survey [start, stop).
     ilo, ihi = (start - first).days, (stop - first).days
-    print('weather', args.include_weather)
     if args.include_weather:
         tweather = weather[ilo:ihi]
     else:
@@ -168,27 +164,34 @@ def calculate_initial_plan(args):
     lst_hist, lst_bins = ephem.get_available_lst(
         nbins=args.nbins, weather=tweather,
         include_twilight=args.include_twilight)
-    if not args.separate_gray_dark:
+    lst_centers = 0.5*(lst_bins[:-1]+lst_bins[1:])
+
+    no_gray_tiles = getattr(config, 'tiles_nogray', False)
+    if not isinstance(no_gray_tiles, bool):
+        no_gray_tiles = no_gray_tiles()
+    if no_gray_tiles:
         grayordark = tiles.OBSCONDITIONS['DARK'] | tiles.OBSCONDITIONS['GRAY']
-        m = (tiles.obsconditions & grayordark) != grayordark
+        mgrayordark = (tiles.tileobsconditions & grayordark) != 0
+        m = (tiles.tileobsconditions[mgrayordark] & grayordark) != grayordark
         if np.any(m):
             log.warning((
                 '{} tiles observable in either dark or gray, but '
-                'not both.  separate_gray_dark is False, so gray and '
+                'not both.  no_gray_tiles is True, so gray and '
                 'dark LST are being optimized together.  For LST planning '
                 'purposes, all gray/dark tiles are assigned to a common '
                 'bucket.').format(np.sum(m)))
         new_lst_hist = lst_hist.copy()
         new_lst_hist[0, :] = lst_hist[0, :] + lst_hist[1, :]
-        new_lst_hist[2, :] = lst_hist[2, :]
-        m = tiles.obsconditions & grayordark != 0
-        tiles.obsconditions[m] = grayordark
+        new_lst_hist[1, :] = lst_hist[2, :]
+        lst_hist = new_lst_hist[0:2, :].copy()
+        m = (tiles.tileobsconditions & grayordark) != 0
+        tiles.tileobsconditions[m] = grayordark
 
     # Initialize the output results table.
-    if not args.separate_gray_dark:
-        conditions = ['DARK', 'GRAY', 'BRIGHT']
-    else:
+    if no_gray_tiles:
         conditions = ['DARK', 'BRIGHT']
+    else:
+        conditions = ['DARK', 'GRAY', 'BRIGHT']
     design = astropy.table.Table()
     design['INIT'] = np.zeros(tiles.ntiles)
     design['HA'] = np.zeros(tiles.ntiles)
@@ -203,24 +206,25 @@ def calculate_initial_plan(args):
         GRAY=args.gray_stretch,
         BRIGHT=args.bright_stretch)
 
-    if not args.separate_gray_dark:
+    if no_gray_tiles:
         stretches.pop('GRAY')
 
     tile_is_assignable = np.zeros(tiles.ntiles, dtype='bool')
     for condition in conditions:
-        tile_is_assignable |= tiles.allowed_in_conditions[condition]
+        tile_is_assignable |= tiles.allowed_in_conditions(condition)
     if ~np.all(tile_is_assignable):
         log.info('Warning: some tiles are not observable in '
                  'gray/dark/bright.  These will not be observable by the NTS '
                  'by default.')
 
     for index, condition in enumerate(conditions):
-        sel = tiles.allowed_in_conditions[condition]
+        sel = tiles.allowed_in_conditions(condition)
         if not np.any(sel):
             log.info('Skipping {} program with no tiles.'.format(condition))
             continue
         # Initialize an LST summary table.
         table = astropy.table.Table(meta={'ORIGIN': lst_bins[0]})
+        table['LST'] = lst_centers
         table['AVAIL'] = lst_hist[index]
         # Initailize an optimizer for this program.
         opt = desisurvey.optimize.Optimizer(

--- a/py/desisurvey/scripts/surveymovie.py
+++ b/py/desisurvey/scripts/surveymovie.py
@@ -143,7 +143,7 @@ class Animator(object):
         self.dec = self.tiles.tileDEC
         self.tileprogram = self.tiles.tileprogram
         self.tileid = self.tiles.tileID
-        self.program_names = self.tiles.programs
+        self.prognames = self.tiles.programs
         nprogram = len(self.prognames)
         self.tiles_per_program = {p: np.sum(self.tiles.program_mask[p])
                                   for p in self.prognames}
@@ -225,12 +225,12 @@ class Animator(object):
                 ax.set_xticks([])
                 ax.set_yticks([])
                 axes.append(ax)
-                # Top-right corner is reserved for integrated progress plots.
+                # Bottom-right corner is reserved for integrated progress plots.
                 if row == 1 and col == 1:
                     ax.set_xlim(0, self.survey_weeks)
                     ax.set_ylim(0, 1)
                     ax.plot([0, self.survey_weeks], [0., 1.], 'w-')
-                    for pname in self.program_names:
+                    for pname in self.prognames:
                         pc = pcolors[pname]
                         xprog = 0.5 + np.arange(self.survey_weeks)
                         # Initialize values to INF so they are not plotted
@@ -241,10 +241,13 @@ class Animator(object):
                             xprog, yprog, lw=2, ls='-',
                             color=pcolors[pname])[0])
                     continue
+                if progidx >= len(self.tiles.programs):
+                    # e.g., for no-gray mode, where we have only two programs.
+                    continue
                 ax.set_xlim(-55, 293)
                 ax.set_ylim(-20, 77)
                 # Draw label for this plot.
-                pname = self.tiles.PROGRAMS[progidx]
+                pname = self.tiles.programs[progidx]
                 pc = pcolors[pname]
                 self.labels.append(ax.annotate(
                     '{0} 100.0%'.format(pname),
@@ -433,7 +436,7 @@ class Animator(object):
             score = self.scores[iexp - self.iexp0]
             max_score = np.max(score)
         for progidx, scatter in enumerate(self.scatters):
-            sel = (self.tileprogram == self.tiles.PROGRAMS[progidx])
+            sel = (self.tileprogram == self.tiles.programs[progidx])
             done = self.status[sel] == 2
             avail = self.available[sel]
             inplan = self.planned[sel]

--- a/py/desisurvey/scripts/surveymovie.py
+++ b/py/desisurvey/scripts/surveymovie.py
@@ -1,4 +1,4 @@
-es"""Script wrapper for creating a movie of survey progress.
+"""Script wrapper for creating a movie of survey progress.
 
 To run this script from the command line, use the ``surveymovie`` entry point
 that is created when this package is installed, and should be in your shell

--- a/py/desisurvey/svstats.py
+++ b/py/desisurvey/svstats.py
@@ -43,15 +43,3 @@ def donefrac_in_conditions(condnexp, configfn=None):
         out['DONEFRAC_'+cond] = out['NNIGHT_'+cond]/(
             out['NNIGHT_NEEDED_'+cond] + (out['NNIGHT_NEEDED_'+cond] == 0))
     return out
-
-    # we then output for each tile what conditions it's still allowed in,
-    # and whether it's done (allowed_in_conditions = 0).
-
-    # would be straightforward to incorporate completeness information
-    # into optimize.py with an additional ~donefrac data structure
-    # that modifies dlst_nom, multiplying it by (1-donefrac) for each tile
-
-    # that also needs to know the donefrac in each condition.
-    # but first step is just to get the donefracs at all.
-
-    # Build the list of nexp for each of these conditions.

--- a/py/desisurvey/svstats.py
+++ b/py/desisurvey/svstats.py
@@ -39,6 +39,11 @@ def donefrac_in_conditions(condnexp, configfn=None):
             nexp = condnexp['NNIGHT_'+cond][ic]
             program = tiles.tileprogram[it]
             out['NNIGHT_'+cond][it] = nexp
+    if tiles.nogray:
+        out['NNIGHT_NEEDED_DARK'] += out['NNIGHT_NEEDED_GRAY']
+        out['NNIGHT_NEEDED_GRAY'] = 0
+        out['NNIGHT_DARK'] += out['NNIGHT_GRAY']
+        out['NNIGHT_GRAY'] = 0
     for cond in CONDITIONS:
         out['DONEFRAC_'+cond] = out['NNIGHT_'+cond]/(
             out['NNIGHT_NEEDED_'+cond] + (out['NNIGHT_NEEDED_'+cond] == 0))

--- a/py/desisurvey/test/test_etc.py
+++ b/py/desisurvey/test/test_etc.py
@@ -86,7 +86,7 @@ class TestExpCalc(unittest.TestCase):
             tnom = getattr(config.nominal_exposure_time, 'DARK')().to(u.day).value
             # Check for sensible exposure estimates.
             tot1, rem1, n1 = ETC.estimate_exposure('DARK', 0., 1.0, 0)
-            tot2, rem2, n2 = ETC.estimate_exposure('GRAY', 0., 1.1, 0)
+            tot2, rem2, n2 = ETC.estimate_exposure('DARK', 0., 1.1, 0)
             self.assertEqual(tot1, tnom)
             self.assertEqual(tot1, rem1)
             self.assertEqual(tot2, rem2)

--- a/py/desisurvey/test/test_plan.py
+++ b/py/desisurvey/test/test_plan.py
@@ -13,7 +13,7 @@ class TestPlan(Tester):
 
     def test_plan(self):
         tiles = desisurvey.tiles.get_tiles()
-        completed = np.zeros(tiles.ntiles, bool)
+        donefrac = np.zeros(tiles.ntiles, 'f4')
         num_nights = (self.stop - self.start).days
         gen = np.random.RandomState(123)
         config = desisurvey.config.Configuration()
@@ -32,11 +32,11 @@ class TestPlan(Tester):
                     self.assertTrue(np.array_equal(planned, planned2))
                     self.assertTrue(np.array_equal(plan.tile_countdown, plan2.tile_countdown))
                     self.assertTrue(np.array_equal(plan.donefrac, plan2.donefrac))
-                    self.assertTrue(np.array_equal(plan.lastexpid, plan2.lastexpid))
                     self.assertTrue(np.array_equal(plan.designha, plan2.designha))
                 # Mark a random set of tiles completed after this night.
-                completed[gen.choice(tiles.ntiles, tiles.ntiles // num_nights)] = True
-                plan.set_donefrac(tiles.tileID, completed, np.zeros(tiles.ntiles))
+                malreadydone = donefrac == 1
+                donefrac[gen.choice(tiles.ntiles, tiles.ntiles // num_nights)] = 1.
+                plan.set_donefrac(tiles.tileID[~malreadydone], donefrac[~malreadydone])
                 # Save and restore our state.
                 plan.save('snapshot.fits')
                 plan2 = Planner(restore='snapshot.fits', simulate=True)

--- a/py/desisurvey/test/test_plan.py
+++ b/py/desisurvey/test/test_plan.py
@@ -24,12 +24,12 @@ class TestPlan(Tester):
             for i in range(num_nights):
                 night = self.start + datetime.timedelta(i)
                 # Run afternoon plan using original and restored objects.
-                avail, pri = plan.afternoon_plan(night)
+                avail, planned = plan.afternoon_plan(night)
                 if plan2 is not None:
                     # Check that the restored planner gives identical results.
-                    avail2, pri2 = plan2.afternoon_plan(night)
+                    avail2, planned2 = plan2.afternoon_plan(night)
                     self.assertTrue(np.array_equal(avail, avail2))
-                    self.assertTrue(np.array_equal(pri, pri2))
+                    self.assertTrue(np.array_equal(planned, planned2))
                     self.assertTrue(np.array_equal(plan.tile_countdown, plan2.tile_countdown))
                     self.assertTrue(np.array_equal(plan.donefrac, plan2.donefrac))
                     self.assertTrue(np.array_equal(plan.lastexpid, plan2.lastexpid))

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -54,14 +54,8 @@ class TestScheduler(Tester):
                     self.assertEqual(field, field2)
                 tileid = next[0]
                 if tileid is not None:
-                    scheduler.update_snr(tileid, 1., 0)
-                    scheduler2.update_snr(tileid, 1., 0)
-                planner.set_donefrac(scheduler.tiles.tileID,
-                                     scheduler.plan.donefrac,
-                                     np.arange(scheduler.tiles.ntiles))
-                planner2.set_donefrac(scheduler2.tiles.tileID,
-                                      scheduler2.plan.donefrac,
-                                      np.arange(scheduler2.tiles.ntiles))
+                    scheduler.update_snr(tileid, 1.)
+                    scheduler2.update_snr(tileid, 1.)
 
 
 def test_suite():

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -34,7 +34,7 @@ class TestScheduler(Tester):
             scheduler2 = Scheduler(planner2)
             self.assertTrue(np.all(planner.donefrac == planner2.donefrac))
             self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
-            self.assertTrue(np.all(scheduler.completed_by_pass == scheduler2.completed_by_pass))
+            self.assertTrue(np.all(scheduler.completed_by_program == scheduler2.completed_by_program))
             avail, planned = planner.afternoon_plan(night, scheduler.completed)
             avail2, planned2 = planner2.afternoon_plan(night, scheduler2.completed)
             self.assertTrue(np.all(avail == avail2))
@@ -46,7 +46,7 @@ class TestScheduler(Tester):
             dusk, dawn = scheduler.night_ephem['dusk'], scheduler.night_ephem['dawn']
             ETC = desisurvey.etc.ExposureTimeCalculator()
             for mjd in np.arange(dusk, dawn, 15. / (24. * 60.)):
-                # TILEID,PASSNUM,SNR2FRAC,EXPFAC,AIRMASS,PROGRAM,PROGEND
+                # TILEID,PROGRAM,SNR2FRAC,EXPFAC,AIRMASS,PROGRAM,PROGEND
                 next = scheduler.next_tile(mjd, ETC, seeing=1.1, transp=0.95, skylevel=1)
                 # Check that the restored scheduler gives the same results.
                 next2 = scheduler2.next_tile(mjd, ETC, seeing=1.1, transp=0.95, skylevel=1)

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -29,12 +29,16 @@ class TestScheduler(Tester):
             night = self.start + datetime.timedelta(i)
             # Save and restore scheduler state.
             planner.save('snapshot.fits')
-            planner2 = desisurvey.plan.Planner(restore='snapshot.fits')
+            planner2 = desisurvey.plan.Planner(restore='snapshot.fits',
+                                               simulate=True)
             scheduler2 = Scheduler(planner2)
-            self.assertTrue(np.all(scheduler.plan.snr2frac == scheduler2.plan.snr2frac))
+            self.assertTrue(np.all(planner.donefrac == planner2.donefrac))
             self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
             self.assertTrue(np.all(scheduler.completed_by_pass == scheduler2.completed_by_pass))
             avail, planned = planner.afternoon_plan(night, scheduler.completed)
+            avail2, planned2 = planner2.afternoon_plan(night, scheduler2.completed)
+            self.assertTrue(np.all(avail == avail2))
+            self.assertTrue(np.all(planned == planned2))
             # Run both schedulers in parallel.
             scheduler.init_night(night)
             scheduler2.init_night(night)
@@ -53,7 +57,11 @@ class TestScheduler(Tester):
                     scheduler.update_snr(tileid, 1., 0)
                     scheduler2.update_snr(tileid, 1., 0)
                 planner.set_donefrac(scheduler.tiles.tileID,
-                                     scheduler.plan.snr2frac, 0*scheduler.snr2frac)
+                                     scheduler.plan.donefrac,
+                                     np.arange(scheduler.tiles.ntiles))
+                planner2.set_donefrac(scheduler2.tiles.tileID,
+                                      scheduler2.plan.donefrac,
+                                      np.arange(scheduler2.tiles.ntiles))
 
 
 def test_suite():

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -23,21 +23,20 @@ class TestScheduler(Tester):
         planner = desisurvey.plan.Planner(simulate=True)
         planner.first_night = desisurvey.utils.get_date('2020-01-01')
         planner.last_night = desisurvey.utils.get_date('2025-01-01')
-        scheduler = Scheduler()
+        scheduler = Scheduler(planner)
         num_nights = (self.stop - self.start).days
         for i in range(num_nights):
             night = self.start + datetime.timedelta(i)
             # Save and restore scheduler state.
             planner.save('snapshot.fits')
-            scheduler2 = Scheduler(restore='snapshot.fits')
-            self.assertTrue(np.all(scheduler.snr2frac == scheduler2.snr2frac))
+            planner2 = desisurvey.plan.Planner(restore='snapshot.fits')
+            scheduler2 = Scheduler(planner2)
+            self.assertTrue(np.all(scheduler.plan.snr2frac == scheduler2.plan.snr2frac))
             self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
             self.assertTrue(np.all(scheduler.completed_by_pass == scheduler2.completed_by_pass))
-            avail, pri = planner.afternoon_plan(night, scheduler.completed)
+            avail, planned = planner.afternoon_plan(night, scheduler.completed)
             # Run both schedulers in parallel.
-            scheduler.update_tiles(avail, pri)
             scheduler.init_night(night)
-            scheduler2.update_tiles(avail, pri)
             scheduler2.init_night(night)
             # Loop over exposures during the night.
             dusk, dawn = scheduler.night_ephem['dusk'], scheduler.night_ephem['dawn']
@@ -49,11 +48,12 @@ class TestScheduler(Tester):
                 next2 = scheduler2.next_tile(mjd, ETC, seeing=1.1, transp=0.95, skylevel=1)
                 for field, field2 in zip(next, next2):
                     self.assertEqual(field, field2)
-                tileid = next[0]                
+                tileid = next[0]
                 if tileid is not None:
                     scheduler.update_snr(tileid, 1., 0)
                     scheduler2.update_snr(tileid, 1., 0)
-                planner.set_donefrac(scheduler.tiles.tileID, scheduler.snr2frac, 0*scheduler.snr2frac)
+                planner.set_donefrac(scheduler.tiles.tileID,
+                                     scheduler.plan.snr2frac, 0*scheduler.snr2frac)
 
 
 def test_suite():

--- a/py/desisurvey/test/test_scheduler.py
+++ b/py/desisurvey/test/test_scheduler.py
@@ -31,12 +31,15 @@ class TestScheduler(Tester):
             planner.save('snapshot.fits')
             planner2 = desisurvey.plan.Planner(restore='snapshot.fits',
                                                simulate=True)
-            scheduler2 = Scheduler(planner2)
             self.assertTrue(np.all(planner.donefrac == planner2.donefrac))
-            self.assertTrue(np.all(scheduler.completed == scheduler2.completed))
-            self.assertTrue(np.all(scheduler.completed_by_program == scheduler2.completed_by_program))
-            avail, planned = planner.afternoon_plan(night, scheduler.completed)
-            avail2, planned2 = planner2.afternoon_plan(night, scheduler2.completed)
+            self.assertTrue(np.all(planner.tile_status == planner2.tile_status))
+            avail, planned = planner.afternoon_plan(night)
+            avail2, planned2 = planner2.afternoon_plan(night)
+            scheduler2 = Scheduler(planner2)
+            self.assertTrue(np.all(scheduler.plan.obsend() ==
+                                   scheduler2.plan.obsend()))
+            self.assertTrue(np.all(scheduler.plan.obsend_by_program() ==
+                                   scheduler2.plan.obsend_by_program()))
             self.assertTrue(np.all(avail == avail2))
             self.assertTrue(np.all(planned == planned2))
             # Run both schedulers in parallel.

--- a/py/desisurvey/test/test_tiles.py
+++ b/py/desisurvey/test/test_tiles.py
@@ -36,8 +36,8 @@ class TestTiles(Tester):
         overlapping = tiles.overlapping
         self.assertEqual(id(overlapping), id(tiles.overlapping))
         # Sanity checks on overlap results.
-        # Assume that the second DARK pass depends on the first DARK pass.
-        DARK1, DARK2 = tiles.program_passes['DARK'][:2]
+        # Assume that the third DARK pass depends on the second DARK pass.
+        DARK1, DARK2 = tiles.program_passes['DARK'][1:3]
         IN1 = (tiles.passnum == DARK1)
         IN2 = (tiles.passnum == DARK2)
         self.assertEqual(len(tile_over[DARK1]), tiles.ntiles)

--- a/py/desisurvey/test/test_tiles.py
+++ b/py/desisurvey/test/test_tiles.py
@@ -17,8 +17,8 @@ class TestTiles(Tester):
         # Verify tile indexing round trip.
         assert np.array_equal(tiles.index(tiles.tileID), np.arange(tiles.ntiles))
         # Verify pass indexing round trip.
-        for passnum in tiles.passes:
-            assert tiles.passes[tiles.pass_index[passnum]] == passnum
+        for program in tiles.programs:
+            assert tiles.programs[tiles.program_index[program]] == program
         # Check reasonable dust and airmass values.
         assert np.all(tiles.dust_factor > 1)
         assert np.all(tiles.airmass(np.zeros(tiles.ntiles)) >= 1)
@@ -30,29 +30,22 @@ class TestTiles(Tester):
 
     def test_overlap(self):
         tiles = Tiles()
-        # Check that overlap attributes are cached.
-        tile_over = tiles.tile_over
-        self.assertEqual(id(tile_over), id(tiles.tile_over))
         overlapping = tiles.overlapping
         self.assertEqual(id(overlapping), id(tiles.overlapping))
         # Sanity checks on overlap results.
-        # Assume that the third DARK pass depends on the second DARK pass.
-        DARK1, DARK2 = tiles.program_passes['DARK'][1:3]
-        IN1 = (tiles.passnum == DARK1)
-        IN2 = (tiles.passnum == DARK2)
-        self.assertEqual(len(tile_over[DARK1]), tiles.ntiles)
-        self.assertFalse(np.any(tile_over[DARK1]))
-        self.assertTrue(np.all(tile_over[DARK2][IN1]))
-        self.assertFalse(np.any(tile_over[DARK2][IN2]))
-
-        self.assertTrue(DARK1 not in overlapping)
-        self.assertEqual(overlapping[DARK2].shape, (tiles.pass_ntiles[DARK2], tiles.pass_ntiles[DARK1]))
-        # Pick a tile in the second DARK pass.
+        # Assume that the DARK program has some overlapping requirements.
+        darkidx = np.flatnonzero(tiles.program_mask['DARK'])
+        brightidx = np.flatnonzero(tiles.program_mask['BRIGHT'])
+        overlapping = tiles.overlapping
+        self.assertTrue(len(overlapping[darkidx[0]]) > 0)
+        # check that bright and dark don't overlap
+        self.assertFalse(np.any(np.isin(brightidx, overlapping[darkidx[0]])))
+        self.assertFalse(np.any(np.isin(darkidx, overlapping[brightidx[0]])))
         config = desisurvey.config.Configuration()
         for N in range(0, 25, 5):
-            IDX2 = np.where(IN2)[0][N]
-            # Find covering tiles in the first DARK pass.
-            IDX1 = np.where(tile_over[DARK2])[0][overlapping[DARK2][N]]
+            IDX2 = darkidx[N]
+            # Find overlapping tiles
+            IDX1 = overlapping[IDX2]
             # Calculate separations.
             sep = desisurvey.utils.separation_matrix(
                 [tiles.tileRA[IDX2]], [tiles.tileDEC[IDX2]],

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -122,7 +122,7 @@ class Tiles(object):
         self._fiberassign_delay = None
 
     CONDITIONS = ['DARK', 'GRAY', 'BRIGHT']
-    CONDITION_INDEX = {i: cond for i, cond in enumerate(CONDITIONS)}
+    CONDITION_INDEX = {cond: i for i, cond in enumerate(CONDITIONS)}
     OBSCONDITIONS = {'DARK': 1, 'GRAY': 2, 'BRIGHT': 4}
     """Mapping of night conditions to OBSCONDITIONS bit mask.
 

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -67,7 +67,8 @@ class Tiles(object):
             m = (tiles['PROGRAM'] == 'GRAY') | (tiles['PROGRAM'] == 'DARK')
             tiles['PROGRAM'][m] = 'DARK'
             obscond = self.OBSCONDITIONS['DARK'] | self.OBSCONDITIONS['GRAY']
-            tiles['OBSCONDITIONS'][m] = obscond
+            m = (tiles['OBSCONDITIONS'] & obscond) != 0
+            tiles['OBSCONDITIONS'][m] |= obscond
         # Copy tile arrays.
         self.tileID = tiles['TILEID'].copy()
         self.passnum = tiles['PASS'].copy()

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -76,6 +76,8 @@ class Tiles(object):
         self.tileDEC = tiles['DEC'].copy()
         self.tileobsconditions = tiles['OBSCONDITIONS'].copy()
         self.tileprogram = np.array([p.strip() for p in tiles['PROGRAM']])
+        self.programs = self.PROGRAMS
+        self.program_index = self.PROGRAM_INDEX
         # Count tiles.
         self.ntiles = len(self.tileID)
         # Can remove this when tile_index no longer uses searchsorted.

--- a/py/desisurvey/tiles.py
+++ b/py/desisurvey/tiles.py
@@ -71,20 +71,13 @@ class Tiles(object):
             tiles['OBSCONDITIONS'][m] |= obscond
         # Copy tile arrays.
         self.tileID = tiles['TILEID'].copy()
-        self.passnum = tiles['PASS'].copy()
+        self.tileprogram = tiles['PROGRAM'].copy()
         self.tileRA = tiles['RA'].copy()
         self.tileDEC = tiles['DEC'].copy()
         self.tileobsconditions = tiles['OBSCONDITIONS'].copy()
         self.tileprogram = np.array([p.strip() for p in tiles['PROGRAM']])
         # Count tiles.
         self.ntiles = len(self.tileID)
-        self.pass_ntiles = {p: np.count_nonzero(self.passnum == p)
-                            for p in np.unique(self.passnum)}
-        # Get list of passes.
-        self.passes = np.unique(self.passnum)
-        self.npasses = len(self.passes)
-        # Map each pass to a small integer index.
-        self.pass_index = {p: idx for idx, p in enumerate(self.passes)}
         # Can remove this when tile_index no longer uses searchsorted.
         if not np.all(np.diff(self.tileID) > 0):
             raise RuntimeError('Tile IDs are not increasing.')
@@ -92,23 +85,14 @@ class Tiles(object):
         self.program_index = {pname: pidx
                               for pidx, pname in enumerate(self.programs)}
 
-        # Build program -> [passes] maps. A program with no tiles will map to an empty array.
-        self.program_passes = {
-            p: np.unique(self.passnum[tiles['PROGRAM'] == p]) for p in self.programs}
-        # Build pass -> program maps.
-        self.pass_program = {}
-        for p in self.programs:
-            self.pass_program.update({passnum: p for passnum in self.program_passes[p]})
-        for p in np.unique(self.passnum):
-            if len(np.unique(tiles['PROGRAM'][tiles['PASS'] == p])) != 1:
-                raise ValueError('At most one program per pass.')
         # Build tile masks for each program. A program will no tiles with have an empty mask.
         self.program_mask = {}
-        for p in self.programs:
-            mask = np.zeros(self.ntiles, bool)
-            for pnum in self.program_passes[p]:
-                mask |= (self.passnum == pnum)
-            self.program_mask[p] = mask
+        for p in self.PROGRAMS:
+            self.program_mask[p] = self.tileprogram == p
+        self.allowed_in_conditions = {}
+        for p in self.OBSCONDITIONS:
+            mask = (self.tileobsconditions & self.OBSCONDITIONS[p]) != 0
+            self.allowed_in_conditions[p] = mask
         # Calculate and save dust exposure factors.
         self.dust_factor = desisurvey.etc.dust_exposure_factor(tiles['EBV_MED'])
         # Precompute coefficients to calculate tile observing airmass.
@@ -118,7 +102,6 @@ class Tiles(object):
         self.tile_coef_B = np.cos(tile_dec_rad) * np.cos(latitude)
         # Placeholders for overlap attributes that are expensive to calculate
         # so we use lazy evaluation the first time they are accessed.
-        self._tile_over = None
         self._overlapping = None
         self._fiberassign_delay = None
 
@@ -214,26 +197,12 @@ class Tiles(object):
         return (self.tileobsconditions & self.OBSCONDITIONS[cond]) != 0
 
     @property
-    def tile_over(self):
-        """Dictionary of tile masks.
-
-        tile_over[passnum] identifies all tiles from a fiber-assignment
-        dependent pass that cover at least one tile in passnum.
-
-        Uses the config parameter ``fiber_assignment_order`` to
-        determine fiber-assignment dependencies.
-        """
-        if self._tile_over is None:
-            self._calculate_overlaps()
-        return self._tile_over
-
-    @property
     def overlapping(self):
         """Dictionary of tile overlap matrices.
 
-        overlapping[passnum][j, k] is True if the j-th tile of passnum is
-        overlapped by the k-th tile of tile_over[passnum]. There is no
-        dictionary entry when the mask tile_over[passnum] is empty.
+        overlapping[program][j, k] is True if the j-th tile of program is
+        overlapped by the k-th tile of tile_over[program]. There is no
+        dictionary entry when the mask tile_over[program] is empty.
         """
         if self._overlapping is None:
             self._calculate_overlaps()
@@ -252,55 +221,41 @@ class Tiles(object):
 
 
     def _calculate_overlaps(self):
-        """Initialize attributes _overlapping and _tile_over.
+        """Initialize attributes _overlapping.
 
-        Uses the config parameters ``fiber_assignment_order`` and
+        Uses the config parameters ``fiber_assignment_delay`` and
         ``tile_diameter`` to determine overlap dependencies.
 
-        This is relatively slow, so only used the first time our ``tile_over``
-        or ``overlapping`` properties are accessed.
+        This is relatively slow, so only used the first time ``overlapping``
+        properties are accessed.
         """
-        self._overlapping = {}
-        self._tile_over = {}
+        self._overlapping = [[] for _ in range(self.ntiles)]
         self._fiberassign_delay = np.full(self.ntiles, -1, int)
         config = desisurvey.config.Configuration()
-        tile_diameter = 2 * config.tile_radius().to(u.deg).value
+        tile_diameter = 2 * config.tile_radius()
 
-        # Validate and parse config.fiber_assignment_order into a dictionary.
-        fiberassign_order = config.fiber_assignment_order
-        Pn = re.compile('^P(\d+)$')
-        RHS = re.compile('^(P\d+(?:\+P\d+)*) delay (\d+)$')
-        fa_rules = {passnum: dict(coveredby=[], delay=0) for passnum in self.passes}
-        for key in fiberassign_order.keys:
-            matched = Pn.match(key)
-            if not matched:
-                raise ValueError('Invalid fiber_assignment_order Pn key: "{}".'.format(key))
-            under_pass = int(matched.group(1))
-            value = getattr(fiberassign_order, key)()
-            matched = RHS.match(value)
-            if not matched:
-                raise ValueError('Invalid fiber_assignment_order RHS value: "{}".'.format(value))
-            over_passes = [int(Pn.match(token).group(1)) for token in matched.group(1).split('+')]
-            delay = int(matched.group(2))
-            fa_rules[under_pass] = dict(coveredby=over_passes, delay=delay)
-
-        # Initialize the data structures behind the attributes defined above.
-        for under_pass in self.passes:
-            fa_rule = fa_rules[under_pass]
-            under_sel = self.passnum == under_pass
-            # Save the delay for tiles in this pass.
-            self._fiberassign_delay[under_sel] = fa_rule['delay']
-            # Build and save a mask of all tiles in passes that cover this pass.
-            over_sel = np.zeros_like(under_sel)
-            for over_pass in fa_rule['coveredby']:
-                over_sel |= (self.passnum == over_pass)
-            self.tile_over[under_pass] = over_sel
-            if np.any(over_sel):
-                # Calculate a boolean matrix of overlaps between tiles in under_pass
-                # and over_passes.
-                self.overlapping[under_pass] = desisurvey.utils.separation_matrix(
-                    self.tileRA[under_sel], self.tileDEC[under_sel],
-                    self.tileRA[over_sel], self.tileDEC[over_sel], tile_diameter)
+        fiber_assignment_delay = config.fiber_assignment_delay
+        for program in Tiles.PROGRAMS:
+            delay = getattr(fiber_assignment_delay, program, None)
+            if delay is not None:
+                delay = delay()
+            else:
+                delay = -1
+            m = self.program_mask[program]
+            rownum = np.flatnonzero(m)
+            self._fiberassign_delay[m] = delay
+            # self._overlapping: list of lists, giving tiles overlapping each
+            # tile
+            if delay < 0:
+                continue
+            from astropy.coordinates import SkyCoord, search_around_sky
+            c = SkyCoord(self.tileRA[m]*u.deg, self.tileDEC[m]*u.deg)
+            idx1, idx2, sep2d, dist3d = search_around_sky(c, c, tile_diameter)
+            for ind1, ind2 in zip(idx1, idx2):
+                if ind1 == ind2:
+                    # ignore self matches
+                    continue
+                self._overlapping[rownum[ind1]].append(rownum[ind2])
 
 
 _cached_tiles = {}
@@ -336,9 +291,8 @@ def get_tiles(tiles_file=None, use_cache=True, write_cache=True):
         tiles = Tiles(tiles_file)
         log.info('Initialized tiles from "{}".'.format(tiles_file))
         for pname in tiles.programs:
-            pinfo = []
-            for passnum in tiles.program_passes[pname]:
-                pinfo.append('{}({})'.format(passnum, tiles.pass_ntiles[passnum]))
+            log.info('{:6s}: {} tiles'.format(
+                pname, np.sum(tiles.program_mask[pname])))
 
     if write_cache:
         _cached_tiles[tiles_file] = tiles


### PR DESCRIPTION
This PR adds the option of calling gray time dark time, and treating the gray layer as just another dark layer.  The mechanism is to optionally in the surveyinit script add the gray time to the dark time and set the gray time to zero, and if that is set, merge the gray tile list with the dark tile list.  Then there is code in desisurvey.tiles to dynamically rename the gray tiles to dark tiles.

That's a little clunky, but I didn't want to go through the pain of changing desimodel's tiles at this point; we're going to have a new set of tiles soon anyway.

I also didn't want to remove the notion of 'gray' from the ephemerides option, since that presently controls the sky brightness, which it seems like should still exist.

There are a lot of knock on changes throughout the code base in places where GRAY was expected as an option.

To implement the SV completeness definition where a tile must be observed in multiple different moon conditions, surveyinit became more complicated to allow tiles to to have different HA optimizations for different conditions.  As part of working on that to handle the "nogray" option, I realized that refactoring most of the internal state out of the scheduler and into the planner would remove some code duplication.  So that change got added in as well.

This has a tiny effect on the tiles that actually get chosen even if config.tiles_nogray = False, because I changed the mechanism by which the program was selected slightly.  In the past I selected the program suitable for the next set of conditions if the next set of conditions started within half a nominal exposure time.  But I didn't want to set up a nogray option to look up the appropriate DARK tiles in gray time, especially given that we'll be changing the program selection to be survey speed related shortly.  So now it's just based on the conditions 5 min in the future.

surveysim also needs a bunch of related changes to accommodate these changes; that's an associated PR.

Now I need to add in the "nopass" option.  That will be another large-ish PR touching both desisurvey and surveysim.  I'll probably try to merge this this weekend, if @dkirkby wants to review.  Thanks!