### PR TITLE
Allow program selection according to current survey speed

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,8 +4,13 @@ desisurvey change log
 
 0.16.1 (unreleased)
 -------------------
+* Allow program selection according to conditions, rather than
+  ephemerides.  Make NTS more robust.  Set max dwell times based on
+  not hitting airmass or observing dark tiles in twilight.  Allow
+  requiring low pass tiles before overlapping high pass tiles, and preferring
+  high pass tiles otherwise.  (PR `#132`)
 
-No changes yet.
+.. _`#132`: https://github.com/desihub/desisurvey/pull/132
 
 0.16.0 (2021-03-31)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -4,6 +4,7 @@ desisurvey change log
 
 0.16.1 (unreleased)
 -------------------
+
 * Allow program selection according to conditions, rather than
   ephemerides.  Make NTS more robust.  Set max dwell times based on
   not hitting airmass or observing dark tiles in twilight.  Allow

--- a/py/desisurvey/data/config.yaml
+++ b/py/desisurvey/data/config.yaml
@@ -53,6 +53,7 @@ programs:
         sbprof: ELG
         minimum_exposure_time: 300 s
         efftime_type: DARK
+        expfac_cut: 2.5
     GRAY:
         min_exposures: 1
         efftime: 1000 s
@@ -60,6 +61,7 @@ programs:
         sbprof: ELG
         minimum_exposure_time: 300 s
         efftime_type: DARK
+        expfac_cut: 2.5
     BRIGHT:
         min_exposures: 1
         efftime: 300 s
@@ -67,6 +69,7 @@ programs:
         sbprof: BGS
         minimum_exposure_time: 180 s
         efftime_type: BRIGHT
+        expfac_cut: 999999
 
 # still used in simulations.
 min_exposures: 2
@@ -118,10 +121,18 @@ maxtime: 60 min
 # Boost priority of already started tiles
 finish_started_priority: 0.0
 
+# Boost priority of later passes (depth first)
+# Only makes sense in combination with tiles_lowpass
+# boost_priority_by_passnum: 0.2
+boost_priority_by_passnum: 0
+
 # Reduce priority of completed tiles
 # ignore_completed_priority: 0.000000001
 ignore_completed_priority: -1
 # in sims, don't repeat finished tiles.
+
+# do program selection by survey speed rather than ephemerides
+select_program_by_speed: False
 
 nominal_conditions:
     # Moon below the horizon
@@ -189,6 +200,9 @@ tiles_nogray: True
 # Trim tile file to only used programs and IN_DESI.
 # Useful for sim visualization and stats tools; not recommended for ops.
 tiles_trim: True
+
+# Require underlying passes to be observed before overlying ones.
+tiles_lowpass: False
 
 # Base path to pre-pended to all non-absolute paths used for reading and
 # writing files managed by this package. The pattern {...} will be expanded

--- a/py/desisurvey/optimize.py
+++ b/py/desisurvey/optimize.py
@@ -160,16 +160,7 @@ class Optimizer(object):
         self.idx = np.where(tile_sel)[0]
         self.ntiles = len(self.ra)
 
-        # Calculate the maximum |HA| in degrees allowed for each tile to stay
-        # above the survey minimum altitude (plus a 5 deg padding).
-        cosZ_min = np.cos(90 * u.deg - (config.min_altitude() + 5 * u.deg))
-        latitude = config.location.latitude()
-        cosHA_min = (
-            (cosZ_min - np.sin(self.dec * u.deg) * np.sin(latitude)) /
-            (np.cos(self.dec * u.deg) * np.cos(latitude))).value
-        self.max_abs_ha = np.degrees(np.arccos(cosHA_min))
-        m = ~np.isfinite(self.max_abs_ha) | (self.max_abs_ha < 3.75)
-        self.max_abs_ha[m] = 7.5  # always give at least a half hour window.
+        self.max_abs_ha = tiles.max_abs_ha[tile_sel]
 
         # Lookup static dust exposure factors for each tile.
         self.dust_factor = tiles.dust_factor[tile_sel]

--- a/py/desisurvey/plan.py
+++ b/py/desisurvey/plan.py
@@ -506,5 +506,3 @@ class Planner(object):
                     # unobserved, overlapping tiles with lower pass numbers.
                     mfree[idx] = 0
         self.tile_available[~mfree] = 0
-        m = ((self.tile_available > 0) &
-             self.tiles.allowed_in_conditions('DARK'))

--- a/py/desisurvey/plots.py
+++ b/py/desisurvey/plots.py
@@ -18,7 +18,8 @@ import desisurvey.utils
 
 
 # Color associated with each program in the functions below.
-program_color = {'DARK': 'black', 'GRAY': 'gray', 'BRIGHT': 'orange'}
+program_color = {'DARK': 'black', 'GRAY': 'gray', 'BRIGHT': 'orange',
+                 'BACKUP': 'green'}
 
 
 def plot_sky_passes(ra, dec, passnum, z, clip_lo=None, clip_hi=None,

--- a/py/desisurvey/scheduler.py
+++ b/py/desisurvey/scheduler.py
@@ -212,11 +212,11 @@ class Scheduler(object):
         if mjd_now > self.night_changes[-1]:
             if verbose:
                 self.log.warning('Tile requested after end of night.')
-        if mjd_now < self.night_ephem['dusk']:
-            return 'BRIGHT', self.night_changes[-1]
-        if mjd_now + 300/86400 > self.night_ephem['dawn']:
-            return 'BRIGHT', self.night_changes[-1]
         if self.select_program_by_speed:
+            if mjd_now < self.night_ephem['dusk']:
+                return 'BRIGHT', self.night_changes[-1]
+            if mjd_now + 300/86400 > self.night_ephem['dawn']:
+                return 'BRIGHT', self.night_changes[-1]
             program = self.conditions_to_program(
                 seeing, transparency, skylevel, airmass=airmass)
             mjd_program_end = self.night_ephem['dawn']

--- a/py/desisurvey/scripts/collect_etc.py
+++ b/py/desisurvey/scripts/collect_etc.py
@@ -108,6 +108,8 @@ def scan_directory(dirname, start_from=None,
         start_exps['QUALITY'] = quality
         comments = np.zeros(len(start_exps), dtype='U80')
         comments[:] = start_exps['COMMENTS']
+        m = start_exps['COMMENTS'].mask
+        comments[m] = ''
         start_exps['COMMENTS'] = comments
         maxexpid = np.max(start_exps['EXPID'])
         for subdir in subdirs:

--- a/py/desisurvey/scripts/surveymovie.py
+++ b/py/desisurvey/scripts/surveymovie.py
@@ -175,7 +175,7 @@ class Animator(object):
         # Count nights with at least one exposure.
         day0 = desisurvey.utils.local_noon_on_date(date_start).mjd
         day_number = np.floor(self.exposures['MJD'] - day0)
-        self.num_nights = len(np.unique(day_number))
+        self.num_nights = len(np.unique(day_number))+1
 
         # Calculate each exposure's LST window.
         exp_midpt = astropy.time.Time(
@@ -417,7 +417,7 @@ class Animator(object):
         if date != self.last_date:
             # Initialize for this night.
             self.init_date(date, night)
-        elif nightly:
+        elif nightly and iexp != len(self.exposures)-1:
             return False
         # Update the top-right label.
         label = '{} {} #{:06d}'.format(self.label, date, info['EXPID'])


### PR DESCRIPTION
* Allow program selection according to current survey speed, rather than ephemerides.  
* Make NTS more robust.  
* Set max dwell times based on not hitting airmass or observing dark tiles in twilight.  
* Allow requiring low pass tiles before overlapping high pass tiles, and preferring high pass tiles otherwise.