### PR TITLE
Do not use legacy PM condition information for tile selection

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,11 +14,15 @@ desisurvey change log
 * Enable identification of high priority 10k footprint tiles.
 * Add slew time to simulations and favor short slews in tile selection.
 * Implement "holding pen" where new fiberassign files are found (PR `#139`_).
-* Miscellaneous holding pen and tile selection improvements (PR `#140`_, `#141`_).
+* Miscellaneous holding pen and tile selection improvements (PR `#140`_,
+  `#141`_).
+* Let ICS move tiles into place.  Make tile selection only use speed
+  (PR `#142`_).
 
 .. _`#139`: https://github.com/desihub/desisurvey/pull/139
 .. _`#140`: https://github.com/desihub/desisurvey/pull/140
 .. _`#141`: https://github.com/desihub/desisurvey/pull/141
+.. _`#142`: https://github.com/desihub/desisurvey/pull/142
 
 0.17.0 (2021-04-23)
 -------------------

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -177,6 +177,65 @@ def azinrange(az, low, high):
     return (az >= low) & (az <= high)
 
 
+def move_tile_into_place(tileid, speculative=False):
+    """Move fiberassign file into place if not already there.
+
+    Observed fiberassign files are kept in DOS_DESI_TILES/FIBER_ASSIGN_DIR,
+    while unobserved ones are kept in FA_HOLDING_PEN.  This routine checks
+    if a given TILEID is already available in the primary location, and
+    otherwise copies it into place from the holding pen.
+
+    Parameters
+    ----------
+    tileid : int
+        the TILEID to copy into place
+    speculative : bool
+        if True, do not perform the actual copy; just check existence.
+    """
+    fadir = os.environ.get('DOS_DESI_TILES', None)
+    if fadir is None:
+        fadir = os.environ.get('FIBER_ASSIGN_DIR', None)
+    if fadir is None:
+        logob.error('DOS_DESI_TILES and FIBER_ASSIGN_DIR not set!')
+        return False
+    tileidstr = '%06d' % tileid
+    fabasefn = os.path.join(tileidstr[0:3], 'fiberassign-%s' % tileidstr)
+    possible_extensions = ['.fits', '.fits.gz']
+    for ext in possible_extensions:
+        if os.path.exists(os.path.join(fadir, fabasefn+ext)):
+            return True
+    # file not present in fadir
+    holdingdir = os.environ.get('FA_HOLDING_PEN', None)
+    if holdingdir is None:
+        logob.error('FA_HOLDING_PEN is not set; cannot find TILEID!')
+        return False
+    extension = None
+    for ext in possible_extensions:
+        if os.path.exists(os.path.join(holdingdir, fabasefn+ext)):
+            extension = ext
+    if extension is None:
+        logob.error('Could not find TILEID {} at {}, failing!'.format(
+            tileid, os.path.join(holdingdir, fabasefn)))
+        return False
+    if speculative:  # skip actual copying.
+        return True
+    os.makedirs(os.path.dirname(os.path.join(fadir, fabasefn)),
+                exist_ok=True, mode=0o2775)
+    shutil.copy(os.path.join(holdingdir, fabasefn+extension),
+                os.path.join(fadir, fabasefn+extension))
+    os.chmod(os.path.join(fadir, fabasefn+extension), 0o664)
+    extraextensions = ['.log', '.png']
+    for ext in extraextensions:
+        if os.path.exists(os.path.join(holdingdir, fabasefn+ext)):
+            shutil.copy(os.path.join(holdingdir, fabasefn+ext),
+                        os.path.join(fadir, fabasefn+ext))
+            os.chmod(os.path.join(fadir, fabasefn+ext), 0o664)
+        else:
+            logob.warning('Could not find expected file {}'.format(
+                os.path.join(holdingdir, fabasefn+ext)))
+    return True
+
+
 class NTS():
     def __init__(self, obsplan=None, defaults={}, night=None,
                  nts_survey=None):
@@ -255,64 +314,6 @@ class NTS():
         for queuedtile in self.queuedlist.queued:
             self.scheduler.plan.add_pending_tile(queuedtile)
         self.ETC = desisurvey.etc.ExposureTimeCalculator()
-
-    def move_tile_into_place(self, tileid, speculative=False):
-        """Move fiberassign file into place if not already there.
-
-        Observed fiberassign files are kept in DOS_DESI_TILES/FIBER_ASSIGN_DIR,
-        while unobserved ones are kept in FA_HOLDING_PEN.  This routine checks
-        if a given TILEID is already available in the primary location, and
-        otherwise copies it into place from the holding pen.
-
-        Parameters
-        ----------
-        tileid : int
-            the TILEID to copy into place
-        speculative : bool
-            if True, do not perform the actual copy; just check existence.
-        """
-        fadir = os.environ.get('DOS_DESI_TILES', None)
-        if fadir is None:
-            fadir = os.environ.get('FIBER_ASSIGN_DIR', None)
-        if fadir is None:
-            self.log.error('DOS_DESI_TILES and FIBER_ASSIGN_DIR not set!')
-            return False
-        tileidstr = '%06d' % tileid
-        fabasefn = os.path.join(tileidstr[0:3], 'fiberassign-%s' % tileidstr)
-        possible_extensions = ['.fits', '.fits.gz']
-        for ext in possible_extensions:
-            if os.path.exists(os.path.join(fadir, fabasefn+ext)):
-                return True
-        # file not present in fadir
-        holdingdir = os.environ.get('FA_HOLDING_PEN', None)
-        if holdingdir is None:
-            self.log.error('FA_HOLDING_PEN is not set; cannot find TILEID!')
-            return False
-        extension = None
-        for ext in possible_extensions:
-            if os.path.exists(os.path.join(holdingdir, fabasefn+ext)):
-                extension = ext
-        if extension is None:
-            self.log.error('Could not find TILEID {} at {}, failing!'.format(
-                tileid, os.path.join(holdingdir, fabasefn)))
-            return False
-        if speculative:  # skip actual copying.
-            return True
-        os.makedirs(os.path.dirname(os.path.join(fadir, fabasefn)),
-                    exist_ok=True, mode=0o2775)
-        shutil.copy(os.path.join(holdingdir, fabasefn+extension),
-                    os.path.join(fadir, fabasefn+extension))
-        os.chmod(os.path.join(fadir, fabasefn+extension), 0o664)
-        extraextensions = ['.log', '.png']
-        for ext in extraextensions:
-            if os.path.exists(os.path.join(holdingdir, fabasefn+ext)):
-                shutil.copy(os.path.join(holdingdir, fabasefn+ext),
-                            os.path.join(fadir, fabasefn+ext))
-                os.chmod(os.path.join(fadir, fabasefn+ext), 0o664)
-            else:
-                self.log.warning('Could not find expected file {}'.format(
-                    os.path.join(holdingdir, fabasefn+ext)))
-        return True
 
     def next_tile(self, conditions=None, exposure=None, constraints=None,
                   speculative=False):
@@ -463,7 +464,7 @@ class NTS():
             self.requestlog.logresponse(badtile)
             return badtile
 
-        if not self.move_tile_into_place(tileid, speculative=speculative):
+        if not move_tile_into_place(tileid, speculative=speculative):
             self.log.error('Could not find tile {}!'.format(tileid))
             self.requestlog.logresponse(badtile)
             return badtile

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -315,6 +315,10 @@ class NTS():
             self.scheduler.plan.add_pending_tile(queuedtile)
         self.ETC = desisurvey.etc.ExposureTimeCalculator()
 
+    # stub to retain ICS API compatibility.
+    def move_tile_into_place(self, tileid, speculative=False):
+        return move_tile_into_place(tileid, speculative=speculative)
+
     def next_tile(self, conditions=None, exposure=None, constraints=None,
                   speculative=False):
         """

--- a/py/desisurvey/NTS.py
+++ b/py/desisurvey/NTS.py
@@ -426,7 +426,7 @@ class NTS():
         if conditions.get('speed_dark_nts') is not None:
             speed = {k.upper(): conditions['speed_%s_nts' % k]
                      for k in ['dark', 'bright', 'backup']}
-        if program is None and speed is not None:
+        if program is None:
             # if no recent speed update, force BRIGHT program.
             transupdated = conditions.get('etc_transparency_updated', None)
             skyupdated = conditions.get('etc_skylevel_updated', None)
@@ -437,6 +437,9 @@ class NTS():
                     program = 'BRIGHT'
                     self.log.info('Conditions last updated more than 30 min '
                                   'in past, using BRIGHT program.')
+            # if no ETC speed information, force BRIGHT.
+            if speed is None:
+                program = 'BRIGHT'
         result = self.scheduler.next_tile(
             mjd, self.ETC, seeing, transparency, skylevel, program=program,
             verbose=True, current_ra=current_ra, current_dec=current_dec,

--- a/py/desisurvey/holdingpen.py
+++ b/py/desisurvey/holdingpen.py
@@ -239,10 +239,10 @@ def execute_svn_maintenance(todelete, tocommit, echo=False, svnrm=False):
 def maintain_holding_pen_and_svn(fbadir, faholddir, mtldonefn):
     todelete, tocommit = maintain_svn(fbadir)
     if len(todelete) + len(tocommit) > 0:
-        logger.info(('To delete from %s: ' % fbadir) +
-                    ' '.join([os.path.basename(x) for x in todelete]))
-        logger.info(('To commit to %s: ' % fbadir) +
-                    ' '.join([os.path.basename(x) for x in tocommit]))
+        logger.info(('To delete from %s:\n' % fbadir) +
+                    '\n'.join([os.path.basename(x) for x in todelete]))
+        logger.info(('To commit to %s:\n' % fbadir) +
+                    '\n'.join([os.path.basename(x) for x in tocommit]))
         qstr = ('Preparing to perform svn fiberassign maintenance, '
                 'deleting {} and committing {} files.  Continue?'.format(
                     len(todelete), len(tocommit)))
@@ -255,8 +255,8 @@ def maintain_holding_pen_and_svn(fbadir, faholddir, mtldonefn):
                 execute_svn_maintenance(todelete, tocommit)
             okay = yesno('Commit to svn?')
             if okay:
-                subprocess.run('svn', 'ci', fbadir,
-                               '-m "Adding newly observed tiles."')
+                subprocess.run(['svn', 'ci', fbadir,
+                                '-m "Adding newly observed tiles."'])
     if mtldonefn is not None:
         invalid = tileid_to_clean(faholddir, fbadir, Table.read(mtldonefn))
     if len(invalid) > 0:

--- a/py/desisurvey/scripts/run_plan.py
+++ b/py/desisurvey/scripts/run_plan.py
@@ -59,8 +59,13 @@ def run_plan(night=None, nts_dir=None, verbose=False, survey=None,
         cond = programs[cidx]
         moon_up_factor = getattr(nts.config.conditions, cond).moon_up_factor()
         expdict = dict(mjd=t0, previoustiles=previoustiles)
+        speed = {
+            'speed_%s_nts' % k.lower():
+            nts.ETC.weather_factor(seeing, 1., moon_up_factor, sbprof=prof)
+            for k, prof in (('DARK', 'ELG'), ('BRIGHT', 'BGS'),
+                            ('BACKUP', 'PSF'))}
         conddict = dict(skylevel=moon_up_factor, seeing=seeing,
-                        sky_ra=current_ra, sky_dec=current_dec)
+                        sky_ra=current_ra, sky_dec=current_dec, **speed)
         res = nts.next_tile(exposure=expdict, conditions=conddict,
                             speculative=True, constraints=constraints)
         if not res['foundtile']:


### PR DESCRIPTION
Do not use legacy PM condition information for tile selection.  
Make it easier for ICS to move tiles into place from the holding pen.
Make nightly simulations use speed interface.  