### PR TITLE
Add -f flag to module swap for new modules version compatibility.

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -42,8 +42,11 @@ if [ -z $NERSC_HOST ]; then
     module use $DESI_PRODUCT_ROOT/modulefiles
     module load desiconda
     module load desimodules/21.7e
-    module swap desitarget/2.5.0
-    module swap fiberassign/5.6.0
+    # need -f switch in recent modules versions to force
+    # swapping even though earlier desitarget / fiberassigns
+    # are dependencies of desimodules/21.7e
+    module swap -f desitarget/2.5.0
+    module swap -f fiberassign/5.6.0
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk
     export SKYHEALPIXS_DIR=$DESI_ROOT/target/skyhealpixs/v1
 else


### PR DESCRIPTION
Newer versions of modules do not allow modules to be swapped if they have prerequisites.  This prevents us from swapping in desired versions of desitarget and fiberassign unless we add the "-f" flag (force) to module swap.  This PR adds that flag.