### PR TITLE
Allow plot object to be returned from forecast_plots()

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisurvey change log
 0.20.1 (unreleased)
 -------------------
 
-* No changes yet
+* Allow plot to be returned from forecast_plots() (PR `#159`_).
+
+.. _`#159`: https://github.com/desihub/desisurvey/pull/159
 
 0.20.0 (2024-04-30)
 -------------------

--- a/py/desisurvey/forecast.py
+++ b/py/desisurvey/forecast.py
@@ -199,7 +199,7 @@ class Forecast(object):
 
 def forecast_plots(tmain=None, exps=None, surveyopsdir=None,
                    include_backup=False, cfgfile=None, ratio=False,
-                   nownight=None, airmasspower=1.25):
+                   nownight=None, airmasspower=1.25, return_plot=False):
     from matplotlib import pyplot as p
     if surveyopsdir is None:
         surveyopsdir = os.environ['DESI_SURVEYOPS']
@@ -338,6 +338,9 @@ def forecast_plots(tmain=None, exps=None, surveyopsdir=None,
         print((timefrac-1)*100)
     print('Dark months ahead: %5.2f' % ((darkfrac - elapsedfrac)*55))
     print('Dark margin: %5.2f%%' % (100*(darkfrac - elapsedfrac)/ elapsedfrac))
+
+    if return_plot:
+        return p
 
 
 def summarize_daterange(


### PR DESCRIPTION
This PR adds a keyword (default of `False` for backward-compatibility) that, if `True`, will return the plot object from `forecast_plots()`.

The justification is that, currently, the plot is displayed in _certain_ environments but not _all_ environments. Returning the object allows the plot to be saved (or manipulated in other ways).