### PR TITLE
set DTCATVER for DARK1B case

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -80,6 +80,9 @@ HA=`echo $LINE | awk '{print $10}'`
 if [[ "$PROGRAM" == "BACKUP" ]]
 then
     DTCATVER=2.2.0
+elif [[ "$PROGRAM" == "DARK1B" ]]
+then
+    DTCATVER=3.0.0
 else
     DTCATVER=1.1.1
 fi


### PR DESCRIPTION
This PR updates the `DTCATVER` value for the `PROGRAM="DARK1B"` case, which will be used for the extension.

When `DTCATVER=3.0.0` catalogs will be available, and downloaded to kpno, and with the proper symlinks added to `1.1.1` catalogs, it would be nice to design few tiles with that to verify that everything works as expected (I don t see why it wouldn t, but better safe than sorry!)

Sorry for doing that a bit late...