### PR TITLE
planplot(): display udpates

### DIFF
--- a/py/desisurvey/scripts/run_plan.py
+++ b/py/desisurvey/scripts/run_plan.py
@@ -59,18 +59,19 @@ def planplot(tileid, plan, title='Nightly plan'):
         p.title(program)
         munobs = plan.tile_status == 'unobs'
         p.scatter(tra[m & munobs], tiles.tileDEC[m & munobs],
-                  alpha=0.3, color='gray', s=5)
+                  alpha=1.0, color='green', s=5, label='unobs ({})'.format((m & munobs).sum()))
         mcomplete = plan.tile_status == 'done'
         p.scatter(tra[m & mcomplete], tiles.tileDEC[m & mcomplete],
-                  alpha=1, color='green', s=5)
+                  alpha=0.1, color='gray', s=5, label='done ({})'.format((m & mcomplete).sum()))
         mpending = ~(munobs | mcomplete)
         p.scatter(tra[m & mpending], tiles.tileDEC[m & mpending],
-                  alpha=1, color='orange', s=20)
+                  alpha=1, color='orange', s=20, label='pending ({})'.format((m & mpending).sum()))
         p.plot(tra[idx], tiles.tileDEC[idx], 'k--')
         p.scatter(tra[m & mtonight], tiles.tileDEC[m & mtonight],
                   alpha=1, facecolors='none', edgecolors='red',
                   s=50, linewidth=3)
-        p.xlim(loff, loff+360)
+        p.xlim(loff+360, loff)
+        p.legend(loc=1)
     p.suptitle(title)
     p.savefig('plan.png')
     p.show()


### PR DESCRIPTION
This PR adds few updates on the `plan.png` plot which is attached to the wiki night plan:
- "done" tiles are now displayed as light gray
- "available" tiles are now displayed as solid green -- as we are getting closer to the end of the survey, it is this quantity that we would want to visualize; for instance, it allows one to easily see where is the region with remaining tiles
- a caption is added, with reporting the number of tiles for each case
- the x-axis is flipped, to follow the usual convention that R.A. increases towards left

Here s an example of the plan with the current main branch:
![plan](https://github.com/user-attachments/assets/958848cd-e422-4990-a15c-4773e0ed22a2)

And here with this PR:
![plan2](https://github.com/user-attachments/assets/fb672cb9-c66e-4f1a-b2b7-11af6450ee5d)
