### PR TITLE
planplot(): handle dark1b/bright1b

### DIFF
--- a/py/desisurvey/scripts/run_plan.py
+++ b/py/desisurvey/scripts/run_plan.py
@@ -51,8 +51,13 @@ def planplot(tileid, plan, title='Nightly plan'):
     mtonight[idx] = True
     from matplotlib import pyplot as p
     allprog = ['DARK', 'BRIGHT', 'BACKUP', 'DARK1B', 'BRIGHT1B']
+    # existing programs
     prog2plot = [
         prog for prog in allprog if prog in tiles.program_mask.keys()
+    ]
+    # existing programs with enabled tiles
+    prog2plot = [
+        prog for prog in prog2plot if tiles.program_mask[prog].sum() > 0
     ]
     nrow = 3
     if 'DARK1B' in prog2plot:

--- a/py/desisurvey/scripts/run_plan.py
+++ b/py/desisurvey/scripts/run_plan.py
@@ -50,12 +50,25 @@ def planplot(tileid, plan, title='Nightly plan'):
     mtonight = np.zeros(tiles.ntiles, dtype='bool')
     mtonight[idx] = True
     from matplotlib import pyplot as p
-    p.figure(figsize=(8.5, 11))
+    allprog = ['DARK', 'BRIGHT', 'BACKUP', 'DARK1B', 'BRIGHT1B']
+    prog2plot = [
+        prog for prog in allprog if prog in tiles.program_mask.keys()
+    ]
+    nrow = 3
+    if 'DARK1B' in prog2plot:
+        p.figure(figsize=(17, 11))
+        ncol = 2
+        ii = [1, 3, 5, 2, 4]
+    else:
+        p.figure(figsize=(8.5, 11))
+        ncol = 1
+        ii = [1, 2, 3]
+    ii = [ii[j] for j in range(len(ii)) if allprog[j] in prog2plot]
     loff = -60
     tra = ((tiles.tileRA - loff) % 360) + loff
-    for i, program in enumerate(['DARK', 'BRIGHT', 'BACKUP']):
+    for i, program in zip(ii, prog2plot):
         m = (tiles.program_mask[program]) & (tiles.in_desi != 0)
-        p.subplot(3, 1, i+1)
+        p.subplot(nrow, ncol, i)
         p.title(program)
         munobs = plan.tile_status == 'unobs'
         p.scatter(tra[m & munobs], tiles.tileDEC[m & munobs],


### PR DESCRIPTION
This PR enables the display of a `DARK1B` and `BRIGHT1B` panel in the `plan.png` figure generated by AP.

The coding may not be the nicer, but hopefully it should work; I m of course happy if someone else comes with a better coding of that.
The behavior should:
- keep current behavior where only `DARK`, `BRIGHT`, `BACKUP` are enabled;
- add a `DARK1B` panel when `DARK1B` will be enabled;
- add two `DARK1B` and `BRIGHT1B` panels when `DARK1B` and `BRIGHT1B` will be enabled.

To develop the code, at nersc, I had to do a bit of hacking: before merging, it would be great to test at kpno, both with current `tiles-main.ecsv` and with a version of that file where some `DARK1B` tiles are enabled.

Here s what the will look like with `DARK1B` (and the `BRIGHT1B` panel would be below the `DARK1B` one):
![plan3](https://github.com/user-attachments/assets/411dc55a-93da-4524-8421-f70e49638cf5)
