### PR TITLE
update fiberassign tag from 5.8.0 to 5.8.1

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -47,7 +47,7 @@ if [ -z $NERSC_HOST ]; then
     # are dependencies of desimodules
     module swap -f desitarget/3.0.0
     module swap -f desimeter/0.8.0
-    module swap -f fiberassign/5.8.0
+    module swap -f fiberassign/5.8.1
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk
     export SKYHEALPIXS_DIR=$DESI_ROOT/target/skyhealpixs/v1
 else


### PR DESCRIPTION
This PR updates the fiberassign tag (previously `5.8.0`, now `5.8.1`) for running operations.
The only difference with previous tag is that the code will not crash anymore if the svn owner is not what is expected (https://github.com/desihub/fiberassign/blob/main/doc/changes.rst#581-2025-05-05).
