### PR TITLE
set DTCATVER for BRIGHT1B case

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -45,7 +45,7 @@ if [ -z $NERSC_HOST ]; then
     # need -f switch in recent modules versions to force
     # swapping even though earlier desitarget / fiberassign
     # are dependencies of desimodules
-    module swap -f desitarget/3.0.0
+    module swap -f desitarget/3.1.0
     module swap -f desimeter/0.8.0
     module swap -f fiberassign/5.8.1
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk

--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -84,6 +84,9 @@ then
 elif [[ "$PROGRAM" == "DARK1B" ]]
 then
     DTCATVER=3.0.0
+elif [[ "$PROGRAM" == "BRIGHT1B" ]]
+then
+    DTCATVER=3.1.0
 else
     DTCATVER=1.1.1
 fi


### PR DESCRIPTION
This PR updates the DTCATVER value for the PROGRAM="BRIGHT1B" case.

@geordie666 : when DTCATVER=3.1.0 catalogs will be available, we will need to downloaded them to  kpno, and add the proper symlinks added to 1.1.1 catalogs.