### PR TITLE
Add lookup_sky_source gaia for BRIGHT1B/M31-M33 tiles

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -137,6 +137,7 @@ fi
 
 # grabbing the RA, DEC, PROGRAM, STATUS, HA for TILEID
 LINE=`awk '{if ($1 == '$TILEID') print $0}' $TILESFN`
+PASS=`echo $LINE | awk '{print $2}'`
 RA=`echo $LINE | awk '{print $3}'`
 DEC=`echo $LINE | awk '{print $4}'`
 PROGRAM=`echo $LINE | awk '{print $5}'`
@@ -172,6 +173,10 @@ then
     CMD="fba_launch --outdir $OUTDIR --tileid $TILEID --tilera $RA --tiledec $DEC --survey main --program $PROGRAM --ha $HA --dtver $DTCATVER --steps qa --log-stdout --doclean y --worldreadable --forcetileid y $CMDEX"
 else
     CMD="fba_launch --outdir $OUTDIR --tileid $TILEID --tilera $RA --tiledec $DEC --survey main --program $PROGRAM --ha $HA --dtver $DTCATVER --nosteps qa --doclean n --worldreadable $CMDEX"
+fi
+if [[ "$PROGRAM" == "BRIGHT1B" ]] && [[ "$PASS" == 8 ]];
+then
+    CMD="`echo $CMD` --lookup_sky_source gaia"
 fi
 echo $CMD
 eval $CMD


### PR DESCRIPTION
This PR adds `--lookup_sky_source gaia` to the `fba_launch` call for the `BRIGHT1B` tiles over M31 and M33.

Those tiles are identified through the `PROGRAM=="BRIGHT1B"` and their `PASS=8` characteristic.
I d appreciate if someone can double-check my work here!

The motivation is that those recently added `main` tiles are outside the LS-DR9 footprint, and there is a setting in `fba_launch` that defaults `lookup_sky_source` to `ls` for main, non-backup tiles.
If using `lookup_sky_source="ls"`, then the fiberassign code won t find any stuck fibers landing on good sky locations (as there is no LS-DR9 sky locations outside the DR9 footprint), and hence will not use any stuck fiber for sky, and use 40x10 working fibers for sky, which is sub-optimal.

Discovery of that issue in this thread: https://desisurvey.slack.com/archives/C01HNN87Y7J/p1754671204248129?thread_ts=1754508356.925239&cid=C01HNN87Y7J.

Note that I find the approach I chose here a bit "hacky", even if it will work here.
I mean,  if some other future stream of the `BRIGHT1B` program is outside, or partially outside, the DR9 footprint, we will have to revise the code.
Ideally, I guess, we d want a criterion like "if this is a main, non-backup tile, and if part (or all) of the tile is outside DR9", then use `--lookup_sky_source gaia` (we could include in the bash script a small python function using healpy, which should be fast).
I raise that point for discussion, in case people are interested in such development.

BTW, those tiles won t have any `BGS` in them, so I doubt that the altmtl folks will rerun those; to be on the safe side, I 
I tag @ashleyjross, to be sure that it is the case (if one would want to rerun those tiles in the altmtl, one would want to be sure to  catch this `--lookup_sky_source gaia` for those tiles).
