### PR TITLE
Update fiberassign on the fly to use desitarget 4.0.0

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -115,7 +115,7 @@ if [ -z $NERSC_HOST ]; then
     # need -f switch in recent modules versions to force
     # swapping even though earlier desitarget / fiberassign
     # are dependencies of desimodules
-    module swap -f desitarget/3.5.0
+    module swap -f desitarget/4.0.0
     module swap -f desimeter/0.8.0
     module swap -f fiberassign/5.8.1
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisurvey change log
 0.21.1 (unreleased)
 -------------------
 
-* no changes yet
+* Update fiberassign-on-the-fly to use desitarget 4.0.0 (PR `#191`_)
+
+.. _`#191`: https://github.com/desihub/desisurvey/pull/191
 
 0.21.0 (2025-08-15)
 -------------------


### PR DESCRIPTION
This PR updates fiberassign on the fly to use `desitarget/4.0.0`. 

The update is necessitated by the bug-fix detailed in [desitarget issue #855](https://github.com/desihub/desitarget/issues/855) and [desitarget PR #856](https://github.com/desihub/desitarget/pull/856).