### PR TITLE
Update fiberassign-on-the-fly to use version 4.1.1 of desitarget

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -115,7 +115,7 @@ if [ -z $NERSC_HOST ]; then
     # need -f switch in recent modules versions to force
     # swapping even though earlier desitarget / fiberassign
     # are dependencies of desimodules
-    module swap -f desitarget/4.0.0
+    module swap -f desitarget/4.1.1
     module swap -f desimeter/0.8.0
     module swap -f fiberassign/5.8.1
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisurvey change log
 0.21.2 (unreleased)
 -------------------
 
-* No changes yet.
+* Update fiberassign-on-the-fly to use desitarget 4.1.1 (PR `#192`_).
+
+.. _`#192`: https://github.com/desihub/desisurvey/pull/192
 
 0.21.1 (2025-09-19)
 -------------------


### PR DESCRIPTION
This PR updates fiberasssign-on-the-fly to use `desitarget/4.1.1` to keep pace with recent changes to the targeting code.