### PR TITLE
Update `fba-main-onthefly.sh` for dr11 fiberassignment. 

### DIFF
--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -165,7 +165,7 @@ else
     DTCATVER=1.1.1
 fi
 
-DR11DTVER=5.1.0
+DR11DTVER=5.2.0
 DTCATVER="${DTCATVER},${DR11DTVER}"
 
 # small sanity check

--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -117,7 +117,7 @@ if [ -z $NERSC_HOST ]; then
     # are dependencies of desimodules
     module swap -f desitarget/5.1.0
     module swap -f desimeter/0.8.0
-    module swap -f fiberassign/6.0.0
+    module swap -f fiberassign/6.0.1
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk
     export SKYHEALPIXS_DIR=$DESI_ROOT/target/skyhealpixs/v1
 else

--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -165,6 +165,9 @@ else
     DTCATVER=1.1.1
 fi
 
+DR11DTVER=5.1.0
+DTCATVER="${DTCATVER},${DR11DTVER}"
+
 # small sanity check
 if [[ "$STATUS" != "unobs" ]]
 then

--- a/bin/fba-main-onthefly.sh
+++ b/bin/fba-main-onthefly.sh
@@ -115,9 +115,9 @@ if [ -z $NERSC_HOST ]; then
     # need -f switch in recent modules versions to force
     # swapping even though earlier desitarget / fiberassign
     # are dependencies of desimodules
-    module swap -f desitarget/4.3.0
+    module swap -f desitarget/5.1.0
     module swap -f desimeter/0.8.0
-    module swap -f fiberassign/5.9.1
+    module swap -f fiberassign/6.0.0
     export DESIMODEL=$DESI_ROOT/survey/ops/desimodel/trunk
     export SKYHEALPIXS_DIR=$DESI_ROOT/target/skyhealpixs/v1
 else


### PR DESCRIPTION
This PR adds the required dr11 catalog version to the `DTCATVER` variable. 